### PR TITLE
Feature/tulcdm 33 show ocr text

### DIFF
--- a/app/assets/stylesheets/temple-dl.css.scss
+++ b/app/assets/stylesheets/temple-dl.css.scss
@@ -178,3 +178,9 @@ h6{
 #digital_collection-show .admin {
   display: none;
 }
+
+#document-content-viewer {
+  width: 980px;
+  height: 150px;
+  margin-top: 20px;
+}

--- a/app/helpers/tul_cdm_helper.rb
+++ b/app/helpers/tul_cdm_helper.rb
@@ -222,7 +222,7 @@ module TulCdmHelper
         end
       end
     end
-    output
+    output.rstrip
   end
 
   def render_compound_pageturner(document)

--- a/app/helpers/tul_cdm_helper.rb
+++ b/app/helpers/tul_cdm_helper.rb
@@ -247,10 +247,13 @@ module TulCdmHelper
       xml = Nokogiri::XML(open(api_path))
       compound_type = xml.xpath("/cpd/type/text()").to_s
       pamphlets_xpath="/cpd/node/page"
+      periodical_xpath="/cpd/node/node/page"
       default_xpath, manuscripts_xpath="/cpd/page"
       case model
         when 'Pamphlet'
           xpath_var = pamphlets_xpath
+        when 'Periodical'
+          xpath_var = periodical_xpath
         else
           xpath_var = default_xpath
       end

--- a/app/views/catalog/_show_document.html.erb
+++ b/app/views/catalog/_show_document.html.erb
@@ -2,6 +2,13 @@
   <%= link_to_download(document, document["contentdm_collection_id_tesim"].to_sentence, document["contentdm_number_tesim"].to_sentence) %>
   <%= @document['model_ssi'] if @document['model_ssi']
   render_compound_pageturner @document if @document["contentdm_number_tesim"] %>
+  <% document_content = compound_document_content(@document) %>
+  <% if not document_content.blank? %>
+    <textarea id='document-content-viewer'>
+      <%= document_content %>
+    </textarea>
+  <% end %>
+    
 </div> 
 <dl class="defList">
   <% document_show_fields.each do |solr_fname, field| -%>

--- a/app/views/catalog/_show_image.html.erb
+++ b/app/views/catalog/_show_image.html.erb
@@ -1,6 +1,13 @@
 <div class="cpd-thumb">
   <%= link_to_download(document, document["contentdm_collection_id_tesim"].to_sentence, document["contentdm_number_tesim"].to_sentence) %>
   <%= render_image_viewer(document, document["contentdm_collection_id_tesim"].to_sentence, document["contentdm_number_tesim"].to_sentence) if document["contentdm_collection_id_tesim"] %>
+  <% if @document['document_content_tesim'] %>
+    <textarea id='document-content-viewer'>
+    <% @document['document_content_tesim'].each do |text_block| %>
+      <%= text_block.to_s %>
+    <% end %>
+    </textarea>
+  <% end %>
 </div>
 <dl class="defList">
   <% document_show_fields.each do |solr_fname, field| -%>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -65,6 +65,24 @@ collections = [
     END
   },
   {
+  collection_alias: 'p245801coll12',
+  name:             'Temple University Yearbooks',
+  thumbnail_url:    'http://digital.library.temple.edu/ui/custom/default/collection/default/resources/custompages/home/templar65_dtl.jpg',
+  image_url:        'http://digital.library.temple.edu/ui/custom/default/collection/coll_p245801coll12/images/Yearbook_widescreen_3.jpg',
+  priority:         91,
+  description:      <<-END.gsub(/^ {6}/, '')
+      <p><span>Temple University has digitized&nbsp;a majority of its yearbooks, including the <em>Templar</em>, its general yearbook, as well as books from its allied health, dental, medical, nursing, podiatry&nbsp;and pharmacy schools. Some professional schools, such as Nursing, Podiatry, and Medicine, had their own pages in the <em>Templar</em> into the 1920s before starting their own yearbooks.</span></p>
+      <p><span>Both the <em>Templar</em> and the medical school yearbook, <em>The Skull</em>, have enjoyed consistent publication and titling from their inception through to their present editions. Other professional school books have appeared less frequently and feature a wide array of titles. They are</span></p>
+      <ul>
+        <li>Allied Health: <em>Plexus</em></li>
+        <li>Dentistry: <em>The Dental Log</em>, <em>The Dent-Owl</em>, <em>The Dental Ray</em>, <em>The Diamond</em>, <em>The Gateway</em>, <em>The Handpiece</em>, <em>Odontolog, Impressions,</em> and <em>The Record</em></li>
+        <li>Nursing: <em>Cross-Bones</em>, <em>Promethean</em>, <em>Promethian</em>, and <em>Reveille</em></li>
+        <li>Podiatry: <em>Tempodian</em>, <em>Templodian</em>, and <em>Achilles</em></li>
+        <li>Pharmacy: <em>The Alembic</em>, <em>Apothecan</em>, <em>Arrex</em>, <em>Asclepian</em>, <em>The Pharmacopian</em>, <em>Pharmacy</em>, <em>Secundum Artem</em> and <em>The Show Globe</em></li>
+      </ul>
+  END
+  },
+  {
   collection_alias: 'p16002coll1',
   name:             'SCRC Audio',
   priority:         112,
@@ -82,7 +100,7 @@ collections = [
   name:             'SCRC Film and Video',
   priority:         131,
   description:      <<-END.gsub(/^ {6}/, '')
-    <p class="cdm_style" style="margin-top: 10px;">The SCRC Film and Video digital collection contains video files from holdings in the Special Collections Research Center (SCRC). Some of the objects in this collection are better contextualized in the following featured collection(s):</p>
+    <p>The SCRC Film and Video digital collection contains video files from holdings in the Special Collections Research Center (SCRC). Some of the objects in this collection are better contextualized in the following featured collection(s):</p>
     <ul>
       <li>
         <div class="cdm_style" style="margin-top: 10px;"><a href="http://northerncity.library.temple.edu/"> Civil Rights in a Northern City: Philadelphia</a></div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,7 +19,6 @@ collections = [
   description:      <<-END.gsub(/^ {6}/, '')
       <p><span>This collection of over 1,500 World War I posters in Temple University Libraries' Special Collections Research Center was donated by George F. Tyler in 1937. The posters provide a graphic portrayal of Allied propaganda used to educate the public and enlist support for the war effort. In addition, they serve as examples of the art, design, and printing techniques of the period.</span></p>
       <p><span>An <a href="http://gamma.library.temple.edu/exhibits/exhibits/show/george-tyler-wwi-poster-exhibi" target="new">exhibition</a> of a selection of the posters is accompanied by primary source material and commentary intended to provide additional context, insight, and interpretation.</span></p>
-      <p>For Americans with Disabilities Act (ADA) accommodation, including help with reading this content, please contact diglib@temple.edu .</p>
     END
   },
   {
@@ -32,7 +31,6 @@ collections = [
       <p>A portion of the Franklin H. Littell papers has been digitized to offer online access.</p>
       <p>Franklin Littell (1917-2009), emeritus professor of religion at Temple University, led a distinguished career that spanned more than seventy years. He was a pacifist and activist, proponent of the Christian Laity and an advocate for new religious movements, an historian, political commentator and supporter of the State of Israel. He devoted ten years to work with the Protestant Churches and Laity in US occupied Germany and more than fifty years to the study and remembrance of the Holocaust and German Church Struggle. Though his activities and affiliations changed over time, he maintained strong beliefs in interfaith understanding and religious liberty his entire life.</p>
       <p">Currently, manuscripts of most of Littell's "Speeches, lectures, and article manuscripts" dating from 1940 to 2002 are available digitally, though more will be added. Also available are correspondence and administrative records relating to his work with the National Council of Methodist Youth from 1934 to 1944.</p>
-      <p>For Americans with Disabilities Act (ADA) accommodation, including help with reading this content, please contact diglib@temple.edu .</p>
     END
   },
   {
@@ -43,7 +41,6 @@ collections = [
   priority:         23,
   description:      <<-END.gsub(/^ {6}/, '')
       <p><span>Search here for sample clippings from the <strong>George D. McDowell Philadelphia Evening Bulletin Collection </strong>digitized in 2010 - 2013.</span></p>
-      <p>For Americans with Disabilities Act (ADA) accommodation, including help with reading this content, please contact diglib@temple.edu .</p>
     END
   },
   {
@@ -54,7 +51,6 @@ collections = [
   priority:         73,
   description:      <<-END.gsub(/^ {6}/, '')
       <p><span>This sheet music published from the early 19th to early 20th centuries, from Temple University Libraries’ collections, contains lithographed and engraved cover art. These covers show remarkable designs and document developing printing techniques throughout more than 100 years. The collections include popular dances and songs, comic tunes that reveal the ironies and anxieties of the time, and music commemorating great exhibitions and honoring heroes and stars.</span></p>
-      <p>For Americans with Disabilities Act (ADA) accommodation, including help with reading this content, please contact diglib@temple.edu .</p>
     END
   },
   {
@@ -66,7 +62,6 @@ collections = [
   description:      <<-END.gsub(/^ {6}/, '')
       <p><span>The Library Prize for Undergraduate Research was established in 2004 to encourage the use of Library resources, to enhance the development of library research techniques, and to honor the best research projects produced each year by Temple University undergraduate students. Up to three projects are selected each year to win $1000. Winning entries exhibit: originality, depth, breadth, or sophistication in the use of library collections; exceptional ability to select, evaluate, synthesize, and utilize library resources in the creation of a project in any media; and evidence of personal growth through the acquisition of newfound knowledge.</span></p>
       <p><span>Also included in this collection are the winning entries for <strong>The Library Prize for Undergraduate Research on Sustainability &amp; the Environment</strong>. Established in the 2010-2011 academic year by Temple Libraries and Gale, a leading organization in e-research and educational publishing, this prize encourage undergraduate research and projects in the area of sustainability. Up to two projects are selected each year to win $1000.</span></p>
-      <p>For Americans with Disabilities Act (ADA) accommodation, including help with reading this content, please contact diglib@temple.edu .</p>
     END
   },
   {
@@ -80,7 +75,6 @@ collections = [
           <div class="cdm_style" style="margin-top: 10px;"><a href="http://northerncity.library.temple.edu/"> Civil Rights in a Northern City: Philadelphia</a></div>
         </li>
       </ul>
-      <p>For Americans with Disabilities Act (ADA) accommodation, including help with reading this content, please contact diglib@temple.edu .</p>
     END
   },
   {
@@ -88,13 +82,36 @@ collections = [
   name:             'SCRC Film and Video',
   priority:         131,
   description:      <<-END.gsub(/^ {6}/, '')
-      <p class="cdm_style" style="margin-top: 10px;">The SCRC Film and Video digital collection contains video files from holdings in the Special Collections Research Center (SCRC). Some of the objects in this collection are better contextualized in the following featured collection(s):</p>
-      <ul>
-        <li>
-          <div class="cdm_style" style="margin-top: 10px;"><a href="http://northerncity.library.temple.edu/"> Civil Rights in a Northern City: Philadelphia</a></div>
-        </li>
-      </ul>
-      <p>For Americans with Disabilities Act (ADA) accommodation, including help with reading this content, please contact diglib@temple.edu .&nbsp;</p>
+    <p class="cdm_style" style="margin-top: 10px;">The SCRC Film and Video digital collection contains video files from holdings in the Special Collections Research Center (SCRC). Some of the objects in this collection are better contextualized in the following featured collection(s):</p>
+    <ul>
+      <li>
+        <div class="cdm_style" style="margin-top: 10px;"><a href="http://northerncity.library.temple.edu/"> Civil Rights in a Northern City: Philadelphia</a></div>
+      </li>
+    </ul>
+  END
+  },
+  {
+  collection_alias: 'p15037coll14',
+  name:             'SCRC Books and Pamphlets',
+  priority:         131,
+  description:      <<-END.gsub(/^ {6}/, '')
+    <p>The SCRC Books and Pamphlets digital collection contains pamphlets and related materials from holdings in the Special Collections Research Center (SCRC). Some of the objects in this collection are better contextualized in the following featured collection(s):</p>
+    <ul>
+      <li>
+        <div class="cdm_style" style="margin-top: 10px;"><a href="http://northerncity.library.temple.edu/">Civil Rights in a Northern City: Philadelphia</a></div>
+      </li>
+    </ul>
+    <ul>
+      <li>
+        <div class="cdm_style" style="margin-top: 10px;"><a href="/cdm/ywcamain/"> YWCA Philadelphia Branches</a></div>
+      </li>
+    </ul>
+    <p>Other sets in this collection: &nbsp;</p>
+    <ul>
+      <li>
+        <div class="cdm_style"><a href="/cdm/search/collection/p15037coll14/searchterm/Beth%20Heinly%20Zine%20Collection/field/digitb/mode/all/conn/and/order/title">Beth Heinly Zine Collection</a></div>
+      </li>
+    </ul>
   END
   }
 ]

--- a/lib/cdm_utils.rb
+++ b/lib/cdm_utils.rb
@@ -90,7 +90,8 @@ module CDMUtils
       end
 
       xml_compound_document = xml_doc.xpath("//record[CONTENTdm_file_name[contains(text(), '.cpd')]]")
-      "<metadata>" + xml_compound_document.to_xml + "</metadata>"
+      xml_text = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<metadata>\n  " + xml_compound_document.to_xml + "\n</metadata>"
+      xml_text.gsub("</record><record>", "</record>\n  <record>")
     end
 
     def self.download(config, coll=nil)

--- a/lib/cdm_utils.rb
+++ b/lib/cdm_utils.rb
@@ -43,6 +43,7 @@ module CDMUtils
       xml_doc = Nokogiri::XML(document)
       compound_object_xpath = "//record[CONTENTdm_file_name[contains(text(), '.cpd')]]"
       compound_object_xpath << "[position() <= 1]" if Rails.env.test? # Limit test scope
+      compound_object_xpath << "[position() <= 6]" if Rails.env.development? # Limit development scope
       compound_object_xpath << "/CONTENTdm_number"
       pointers = xml_doc.xpath(compound_object_xpath)
 
@@ -89,7 +90,7 @@ module CDMUtils
       end
 
       xml_compound_document = xml_doc.xpath("//record[CONTENTdm_file_name[contains(text(), '.cpd')]]")
-      "<manifest>" + xml_compound_document.to_xml + "</manifest>"
+      "<metadata>" + xml_compound_document.to_xml + "</metadata>"
     end
 
     def self.download(config, coll=nil)
@@ -211,9 +212,7 @@ module CDMUtils
         
         #periodical
         when 'p15037coll4', 'p15037coll9', 'p15037coll6', 'p16002coll8', 'p245801coll12'
-          puts "xsltproc #{Rails.root}/lib/tasks/cdm_to_foxml_periodical.xsl #{file_name}"
-          #`xsltproc #{Rails.root}/lib/tasks/cdm_to_foxml_periodical.xsl #{file_name}`
-          exec "xsltproc #{Rails.root}/lib/tasks/cdm_to_foxml_periodical.xsl #{file_name}"
+          `xsltproc #{Rails.root}/lib/tasks/cdm_to_foxml_periodical.xsl #{file_name}`
         
         #poster
         when 'p16002coll9'
@@ -246,7 +245,7 @@ module CDMUtils
       puts "XSLT transformation complete for #{fname}".green
 
       # Delete the source XML file
-      File.delete(file_name)
+      #File.delete(file_name)
     end
   end
 

--- a/lib/cdm_utils.rb
+++ b/lib/cdm_utils.rb
@@ -246,7 +246,7 @@ module CDMUtils
       puts "XSLT transformation complete for #{fname}".green
 
       # Delete the source XML file
-      #File.delete(file_name)
+      File.delete(file_name)
     end
   end
 

--- a/spec/lib/cdm_utils_spec.rb
+++ b/spec/lib/cdm_utils_spec.rb
@@ -6,6 +6,7 @@ describe 'List CONTENTdm collections' do
   let (:collection_name) { "p16002coll9" }
   let (:collection_title) { "Allied Posters of World War I" }
   let (:private_collection_name) { "p16002coll11" }
+  let (:yearbook_collection_name) { "p245801coll12" }
   let (:cdm_data_root) { "#{Rails.root}/spec/fixtures/fedora/cdm" }
   let (:schema_url) { "http://www.fedora.info/definitions/1/0/foxml1-1.xsd" }
   let (:download_directory) { config['cdm_download_dir'] }
@@ -52,6 +53,18 @@ describe 'List CONTENTdm collections' do
         expect(file_count).to eq(0)
       end
     end
+
+    it "should harvest yearbook document content" do
+      VCR.use_cassette "cdm-util-download/should_harvest_yearbook_document_content" do
+        downloaded = CDMUtils.download_one_collection(config, yearbook_collection_name)
+        file_count = Dir[File.join(download_directory, '*.xml')].count { |file| File.file?(file) }
+        file = File.join(download_directory, yearbook_collection_name + '.xml')
+        doc = Nokogiri::XML(File.read(file))
+        # Tests for both metadata and attempted access to private collection
+        expect(doc).to have_tag('Document_Content')
+      end
+    end
+
   end
 
   describe 'convert' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -47,4 +47,10 @@ RSpec.configure do |config|
   # The different available types are documented in the features, such as in
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
+
+  VCR.configure do |c|
+    # Don't record transactions with local Jetty and rails servers
+    c.ignore_localhost = true
+  end
+
 end


### PR DESCRIPTION
- Displays OCR text for simple object.
- Aggregates OCR text for compound objects for indexing. Does not display OCR text for compound objects.
- Renders periodicals (yearbooks) in page turner
