### PR TITLE
Feature/tulcdm 50 implement optional download link

### DIFF
--- a/app/helpers/tul_cdm_helper.rb
+++ b/app/helpers/tul_cdm_helper.rb
@@ -31,6 +31,8 @@ module TulCdmHelper
   
   def link_to_download(document, collection_id, cdm_number)
 
+    return if !is_downloadable?(document)
+
     output = ''
     config = YAML.load_file(File.expand_path("#{Rails.root}/config/contentdm.yml", __FILE__))
     model = model_from_document(document)
@@ -484,6 +486,12 @@ module TulCdmHelper
       end
     end
     images.html_safe
+  end
+
+  def is_downloadable? (document)
+    # It isn't downloadable if there's a "No" in any of the downloadable elements
+    # Otherwise, "Yes" must be explicitly stateda
+    !document['downloadable_ssm'].include?("No") && document['downloadable_ssm'].last.eql?("Yes")
   end
 
 end

--- a/app/helpers/tul_cdm_helper.rb
+++ b/app/helpers/tul_cdm_helper.rb
@@ -489,8 +489,9 @@ module TulCdmHelper
   end
 
   def is_downloadable? (document)
-    # It isn't downloadable if there's a "No" in any of the downloadable elements
-    # Otherwise, "Yes" must be explicitly stateda
+    # Assumes downloadable is in an array, eventhough it should not be multivalued.
+    # Item is not downloadable if a "No" exists in any of the downloadable elements
+    # Otherwise, "Yes" must be explicitly stated
     !document['downloadable_ssm'].include?("No") && document['downloadable_ssm'].last.eql?("Yes")
   end
 

--- a/app/models/audio.rb
+++ b/app/models/audio.rb
@@ -1,35 +1,34 @@
 class Audio < TulCdm::Models::Audiovisual
-  
+
   has_metadata "descMetadata", type: AudioMetadata
   has_metadata "geographicMetadata", :type => TulCdm::Datastreams::GeographicDatastream
   has_metadata "physicalMetadata", :type => TulCdm::Datastreams::PhysicalDatastream
   has_metadata "digitalMetadata", :type => TulCdm::Datastreams::DigitalDatastream
   has_metadata "creationMetadata", :type => TulCdm::Datastreams::CreationDatastream
   has_metadata "volumeMetadata", :type => TulCdm::Datastreams::VolumeDatastream
-  
-  has_attributes :title,:format,:type, :publisher,:digital_collection,:digital_publisher,
-    :digital_specifications,:contact,:repository,:repository_collection, :language, 
-    :identifier, datastream: 'objectMetadata', multiple: true
 
-  has_attributes :avsource, :clip_summary, :date_broadcast, :ensemble_identifier, 
+  has_attributes :title,:format,:type, :publisher,:digital_collection,:digital_publisher,
+    :digital_specifications,:contact,:repository,:repository_collection, :language,
+    :identifier, :downloadable, datastream: 'objectMetadata', multiple: true
+
+  has_attributes :avsource, :clip_summary, :date_broadcast, :ensemble_identifier,
     :timecode_begin, :timecode_end, :transcript_filename, :original_source_summary,
     :original_source_title, datastream: 'avMetadata', multiple: true
-  
-  has_attributes :item_url, :oclc_number, :date_created, :date_modified, :contentdm_number, 
+
+  has_attributes :item_url, :oclc_number, :date_created, :date_modified, :contentdm_number,
     :contentdm_file_name, :contentdm_file_path, :contentdm_collection_id, datastream: 'contentdmMetadata', multiple: false
-  
+
   has_attributes :contributor, datastream: 'descMetadata', multiple: true
 
   has_attributes :geographic_subject, :organization_building, datastream: 'geographicMetadata', multiple: true
-  
+
   has_attributes :folder, :location, :physical_description, datastream: 'physicalMetadata', multiple: true
 
   has_attributes :notes, :personal_names, datastream: 'notationsMetadata', multiple: true
-  
+
   has_attributes :file_name, :document_content, datastream: 'digitalMetadata', multiple: true
 
   has_attributes :created, :creator, datastream: 'creationMetadata', multiple: true
 
 
 end
-

--- a/app/models/clipping.rb
+++ b/app/models/clipping.rb
@@ -1,5 +1,5 @@
 class Clipping < TulCdm::Models::Base
-  
+
   has_metadata "descMetadata", type: ClippingMetadata
   has_metadata "geographicMetadata", :type => TulCdm::Datastreams::GeographicDatastream
   has_metadata "physicalMetadata", :type => TulCdm::Datastreams::PhysicalDatastream
@@ -8,20 +8,20 @@ class Clipping < TulCdm::Models::Base
   has_metadata "creationMetadata", :type => TulCdm::Datastreams::CreationDatastream
 
    has_attributes :title,:format,:type, :publisher,:digital_collection,:digital_publisher,
-      :digital_specifications,:contact,:repository,:repository_collection, :language, 
-      :identifier, datastream: 'objectMetadata', multiple: true
-  
-  has_attributes :item_url, :oclc_number, :date_created, :date_modified, :contentdm_number, 
+      :digital_specifications,:contact,:repository,:repository_collection, :language,
+      :identifier, :downloadable, datastream: 'objectMetadata', multiple: true
+
+  has_attributes :item_url, :oclc_number, :date_created, :date_modified, :contentdm_number,
    :contentdm_file_name, :contentdm_file_path, :contentdm_collection_id, datastream: 'contentdmMetadata', multiple: false
 
   has_attributes :author, :image_number, datastream: 'descMetadata', multiple: true
-  
+
   has_attributes :geographic_subject, :organization_building, datastream: 'geographicMetadata', multiple: true
-  
+
   has_attributes :folder, :location, :physical_description, datastream: 'physicalMetadata', multiple: true
 
   has_attributes :notes, :personal_names, datastream: 'notationsMetadata', multiple: true
-  
+
   has_attributes :file_name, :document_content, datastream: 'digitalMetadata', multiple: true
 
   has_attributes :created, :creator, datastream: 'creationMetadata', multiple: true

--- a/app/models/ephemera.rb
+++ b/app/models/ephemera.rb
@@ -1,27 +1,27 @@
 class Ephemera < TulCdm::Models::Base
-  
+
   has_metadata "descMetadata", type: EphemeraMetadata
   has_metadata "geographicMetadata", :type => TulCdm::Datastreams::GeographicDatastream
   has_metadata "physicalMetadata", :type => TulCdm::Datastreams::PhysicalDatastream
   has_metadata "notationsMetadata", :type => TulCdm::Datastreams::NotationsDatastream
   has_metadata "digitalMetadata", :type => TulCdm::Datastreams::DigitalDatastream
   has_metadata "creationMetadata", :type => TulCdm::Datastreams::CreationDatastream
-  
+
   has_attributes :title,:format,:type, :publisher,:digital_collection,:digital_publisher,
-      :digital_specifications,:contact,:repository,:repository_collection, :language, 
-      :identifier, datastream: 'objectMetadat', multiple: true
-  
-  has_attributes :item_url, :oclc_number, :date_created, :date_modified, :contentdm_number, 
+      :digital_specifications,:contact,:repository,:repository_collection, :language,
+      :identifier, :downloadable, datastream: 'objectMetadat', multiple: true
+
+  has_attributes :item_url, :oclc_number, :date_created, :date_modified, :contentdm_number,
    :contentdm_file_name, :contentdm_file_path, :contentdm_collection_id, datastream: 'contentdmMetadata', multiple: false
 
   has_attributes :corporate_name, :series, :stereotypical_object_note, datastream: 'descMetadata', multiple: true
-  
+
   has_attributes :geographic_subject, :organization_building, datastream: 'geographicMetadata', multiple: true
-  
+
   has_attributes :folder, :location, :physical_description, datastream: 'physicalMetadata', multiple: true
 
   has_attributes :notes, :personal_names, datastream: 'notationsMetadata', multiple: true
-  
+
   has_attributes :file_name, :document_content, datastream: 'digitalMetadata', multiple: true
 
   has_attributes :created, :creator, datastream: 'creationMetadata', multiple: true

--- a/app/models/manuscript.rb
+++ b/app/models/manuscript.rb
@@ -1,5 +1,5 @@
 class Manuscript < TulCdm::Models::Base
-  
+
   has_metadata "descMetadata", type: ManuscriptMetadata
   has_metadata "geographicMetadata", :type => TulCdm::Datastreams::GeographicDatastream
   has_metadata "physicalMetadata", :type => TulCdm::Datastreams::PhysicalDatastream
@@ -7,26 +7,26 @@ class Manuscript < TulCdm::Models::Base
   has_metadata "digitalMetadata", :type => TulCdm::Datastreams::DigitalDatastream
   has_metadata "creationMetadata", :type => TulCdm::Datastreams::CreationDatastream
   has_metadata "volumeMetadata", :type => TulCdm::Datastreams::VolumeDatastream
-  
+
   has_attributes :title,:format,:type, :publisher,:digital_collection,:digital_publisher,
-      :digital_specifications,:contact,:repository,:repository_collection, :language, 
-      :identifier, datastream: :objectMetadata, multiple: true
-  
-  has_attributes :item_url, :oclc_number, :date_created, :date_modified, :contentdm_number, 
+      :digital_specifications,:contact,:repository,:repository_collection, :language,
+      :identifier, :downloadable, datastream: :objectMetadata, multiple: true
+
+  has_attributes :item_url, :oclc_number, :date_created, :date_modified, :contentdm_number,
    :contentdm_file_name, :contentdm_file_path, :contentdm_collection_id, datastream: 'contentdmMetadata', multiple: false
 
   has_attributes :creator_organization, :creator_person, :other_creator_organization, :other_creator_person, datastream: 'descMetadata', multiple: true
-  
+
   has_attributes :geographic_subject, :organization_building, datastream: 'geographicMetadata', multiple: true
-  
+
   has_attributes :folder, :location, :physical_description, datastream: 'physicalMetadata', multiple: true
 
   has_attributes :notes, :personal_names, datastream: 'notationsMetadata', multiple: true
-  
+
   has_attributes :file_name, :document_content, datastream: 'digitalMetadata', multiple: true
 
   has_attributes :created, :creator, datastream: 'creationMetadata', multiple: true
 
   has_attributes :local_call_number, :number_of_pages, datastream: 'volumeMetadata', multiple: false
-  
+
 end

--- a/app/models/pamphlet.rb
+++ b/app/models/pamphlet.rb
@@ -6,22 +6,22 @@ class Pamphlet < TulCdm::Models::Base
   has_metadata "notationsMetadata", :type => TulCdm::Datastreams::NotationsDatastream
   has_metadata "digitalMetadata", :type => TulCdm::Datastreams::DigitalDatastream
   has_metadata "creationMetadata", :type => TulCdm::Datastreams::CreationDatastream
-    
+
   has_attributes :title,:format,:type, :publisher,:digital_collection,:digital_publisher,
-      :digital_specifications,:contact,:repository,:repository_collection, :language, 
-      :identifier, datastream: :objectMetadata, multiple: true
-  
-  has_attributes :item_url, :oclc_number, :date_created, :date_modified, :contentdm_number, 
+      :digital_specifications,:contact,:repository,:repository_collection, :language,
+      :identifier, :downloadable, datastream: :objectMetadata, multiple: true
+
+  has_attributes :item_url, :oclc_number, :date_created, :date_modified, :contentdm_number,
    :contentdm_file_name, :contentdm_file_path, :contentdm_collection_id, datastream: 'contentdmMetadata', multiple: false
 
   has_attributes :author, :date_of_publication, :internal_note, datastream: 'descMetadata', multiple: true
-  
+
   has_attributes :geographic_subject, :organization_building, datastream: 'geographicMetadata', multiple: true
-  
+
   has_attributes :folder, :location, :physical_description, datastream: 'physicalMetadata', multiple: true
 
   has_attributes :notes, :personal_names, datastream: 'notationsMetadata', multiple: true
-  
+
   has_attributes :file_name, :document_content, datastream: 'digitalMetadata', multiple: true
 
   has_attributes :created, :creator, datastream: 'creationMetadata', multiple: true

--- a/app/models/periodical.rb
+++ b/app/models/periodical.rb
@@ -1,21 +1,21 @@
 class Periodical < TulCdm::Models::Base
-  
+
   has_metadata "descMetadata", type: PeriodicalMetadata
   has_metadata "notationsMetadata", :type => TulCdm::Datastreams::NotationsDatastream
   has_metadata "digitalMetadata", :type => TulCdm::Datastreams::DigitalDatastream
   has_metadata "creationMetadata", :type => TulCdm::Datastreams::CreationDatastream
-  
+
   has_attributes :title,:format,:type, :publisher,:digital_collection,:digital_publisher,
-      :digital_specifications,:contact,:repository,:repository_collection, :language, 
+      :digital_specifications,:contact,:repository,:repository_collection, :language,
       :identifier, datastream: :objectMetadata, multiple: true
-  
-  has_attributes :item_url, :oclc_number, :date_created, :date_modified, :contentdm_number, 
-   :contentdm_file_name, :contentdm_file_path, :contentdm_collection_id, datastream: 'contentdmMetadata', multiple: false
+
+  has_attributes :item_url, :oclc_number, :date_created, :date_modified, :contentdm_number,
+   :contentdm_file_name, :downloadable, :contentdm_file_path, :contentdm_collection_id, datastream: 'contentdmMetadata', multiple: false
 
   has_attributes :issue_title, :ocr_note, datastream: 'descMetadata', multiple: true
-  
+
   has_attributes :notes, :personal_names, datastream: 'notationsMetadata', multiple: true
-  
+
   has_attributes :file_name, :document_content, datastream: 'digitalMetadata', multiple: true
 
   has_attributes :created, :creator, datastream: 'creationMetadata', multiple: true

--- a/app/models/periodical.rb
+++ b/app/models/periodical.rb
@@ -7,10 +7,10 @@ class Periodical < TulCdm::Models::Base
 
   has_attributes :title,:format,:type, :publisher,:digital_collection,:digital_publisher,
       :digital_specifications,:contact,:repository,:repository_collection, :language,
-      :identifier, datastream: :objectMetadata, multiple: true
+      :identifier, :downloadable, datastream: :objectMetadata, multiple: true
 
   has_attributes :item_url, :oclc_number, :date_created, :date_modified, :contentdm_number,
-   :contentdm_file_name, :downloadable, :contentdm_file_path, :contentdm_collection_id, datastream: 'contentdmMetadata', multiple: false
+   :contentdm_file_name, :contentdm_file_path, :contentdm_collection_id, datastream: 'contentdmMetadata', multiple: false
 
   has_attributes :issue_title, :ocr_note, datastream: 'descMetadata', multiple: true
 

--- a/app/models/photograph.rb
+++ b/app/models/photograph.rb
@@ -1,27 +1,27 @@
 class Photograph < TulCdm::Models::Base
-  
+
   has_metadata "descMetadata", type: PhotographMetadata
   has_metadata "geographicMetadata", :type => TulCdm::Datastreams::GeographicDatastream
   has_metadata "physicalMetadata", :type => TulCdm::Datastreams::PhysicalDatastream
   has_metadata "notationsMetadata", :type => TulCdm::Datastreams::NotationsDatastream
   has_metadata "digitalMetadata", :type => TulCdm::Datastreams::DigitalDatastream
   has_metadata "creationMetadata", :type => TulCdm::Datastreams::CreationDatastream
-       
+
   has_attributes :title,:format,:type, :publisher,:digital_collection,:digital_publisher,
-      :digital_specifications,:contact,:repository,:repository_collection, :language, 
-      :identifier, datastream: :objectMetadata, multiple: true
-  
-  has_attributes :item_url, :oclc_number, :date_created, :date_modified, :contentdm_number, 
+      :digital_specifications,:contact,:repository,:repository_collection, :language,
+      :identifier, :downloadable, datastream: :objectMetadata, multiple: true
+
+  has_attributes :item_url, :oclc_number, :date_created, :date_modified, :contentdm_number,
    :contentdm_file_name, :contentdm_file_path, :contentdm_collection_id, datastream: 'contentdmMetadata', multiple: false
-  
+
   has_attributes :original_notes, :photographer, :intersection, datastream: 'descMetadata', multiple: true
-  
+
   has_attributes :geographic_subject, :organization_building, datastream: 'geographicMetadata', multiple: true
-  
+
   has_attributes :folder, :location, :physical_description, datastream: 'physicalMetadata', multiple: true
 
   has_attributes :notes, :personal_names, datastream: 'notationsMetadata', multiple: true
-  
+
   has_attributes :file_name, :document_content, datastream: 'digitalMetadata', multiple: true
 
   has_attributes :created, :creator, datastream: 'creationMetadata', multiple: true

--- a/app/models/poster.rb
+++ b/app/models/poster.rb
@@ -1,27 +1,27 @@
 class Poster < TulCdm::Models::Base
-  
+
   has_metadata "descMetadata", type:PosterMetadata
   has_metadata "physicalMetadata", :type => TulCdm::Datastreams::PhysicalDatastream
   has_metadata "digitalMetadata", :type => TulCdm::Datastreams::DigitalDatastream
   has_metadata "notationsMetadata", :type => TulCdm::Datastreams::NotationsDatastream
   has_metadata "creationMetadata", :type => TulCdm::Datastreams::CreationDatastream
-  
+
   has_attributes :title,:format,:type, :publisher,:digital_collection,:digital_publisher,
-      :digital_specifications,:contact,:repository,:repository_collection, :language, 
-      :identifier, datastream: :objectMetadata, multiple: true
-  
-  has_attributes :item_url, :oclc_number, :date_created, :date_modified, :contentdm_number, 
+      :digital_specifications,:contact,:repository,:repository_collection, :language,
+      :identifier, :downloadable, datastream: :objectMetadata, multiple: true
+
+  has_attributes :item_url, :oclc_number, :date_created, :date_modified, :contentdm_number,
    :contentdm_file_name, :contentdm_file_path, :contentdm_collection_id, datastream: 'contentdmMetadata', multiple: false
-  
-  has_attributes :alternate_title, :acknowledgment, :alternate_title, :contributor, :corporate_name, 
+
+  has_attributes :alternate_title, :acknowledgment, :alternate_title, :contributor, :corporate_name,
       :hidden_date, :series, :volume, datastream: 'descMetadata', multiple: true
-  
+
   has_attributes :folder, :location, :physical_description, datastream: 'physicalMetadata', multiple: true
 
   has_attributes :notes, :personal_names, datastream: 'notationsMetadata', multiple: true
-  
+
   has_attributes :file_name, :document_content, datastream: 'digitalMetadata', multiple: true
 
   has_attributes :created, :creator, datastream: 'creationMetadata', multiple: true
-  
+
 end

--- a/app/models/scholarship.rb
+++ b/app/models/scholarship.rb
@@ -1,21 +1,21 @@
 class Scholarship < TulCdm::Models::Base
-  
+
   has_metadata "descMetadata", type: ScholarshipMetadata
   has_metadata "digitalMetadata", :type => TulCdm::Datastreams::DigitalDatastream
   has_metadata "creationMetadata", :type => TulCdm::Datastreams::CreationDatastream
   has_metadata "volumeMetadata", :type => TulCdm::Datastreams::VolumeDatastream
-  
+
   has_attributes :title,:format,:type, :publisher,:digital_collection,:digital_publisher,
-      :digital_specifications,:contact,:repository,:repository_collection, :language, 
-      :identifier, datastream: 'objectMetadata', multiple: true
-  
-  has_attributes :item_url, :oclc_number, :date_created, :date_modified, :contentdm_number, 
+      :digital_specifications,:contact,:repository,:repository_collection, :language,
+      :identifier, :downloadable, datastream: :objectMetadata, multiple: true
+
+  has_attributes :item_url, :oclc_number, :date_created, :date_modified, :contentdm_number,
    :contentdm_file_name, :contentdm_file_path, :contentdm_collection_id, datastream: 'contentdmMetadata', multiple: false
-  
-  has_attributes :abstract, :accompanied_by, :accompanies, :advisor, :contributor, :author, :committee_members, :degree, 
-   :degree_granting_institution, :department, :embargo_statement, :file_size, :keywords, :restriction_note, :source, 
+
+  has_attributes :abstract, :accompanied_by, :accompanies, :advisor, :contributor, :author, :committee_members, :degree,
+   :degree_granting_institution, :department, :embargo_statement, :file_size, :keywords, :restriction_note, :source,
    :alternate_title, :year_degree_awarded, :ocr_note , datastream: 'descMetadata', multiple: true
-  
+
   has_attributes :file_name, :document_content, datastream: 'digitalMetadata', multiple: true
 
   has_attributes :created, :creator, datastream: 'creationMetadata', multiple: true
@@ -23,4 +23,3 @@ class Scholarship < TulCdm::Models::Base
   has_attributes :local_call_number, :number_of_pages, datastream: 'volumeMetadata', multiple: false
 
 end
- 

--- a/app/models/sheet_music.rb
+++ b/app/models/sheet_music.rb
@@ -1,23 +1,23 @@
 class SheetMusic < TulCdm::Models::Base
-  
+
   has_metadata "descMetadata", type: SheetMusicMetadata
   has_metadata "physicalMetadata", :type => TulCdm::Datastreams::PhysicalDatastream
   has_metadata "digitalMetadata", :type => TulCdm::Datastreams::DigitalDatastream
   has_metadata "creationMetadata", :type => TulCdm::Datastreams::CreationDatastream
   has_metadata "volumeMetadata", :type => TulCdm::Datastreams::VolumeDatastream
-  
+
   has_attributes :title,:format,:type, :publisher,:digital_collection,:digital_publisher,
-      :digital_specifications,:contact,:repository,:repository_collection, :language, 
-      :identifier, datastream: :objectMetadata, multiple: true
-  
-  has_attributes :item_url, :oclc_number, :date_created, :date_modified, :contentdm_number, 
+      :digital_specifications,:contact,:repository,:repository_collection, :language,
+      :identifier, :downloadable, datastream: :objectMetadata, multiple: true
+
+  has_attributes :item_url, :oclc_number, :date_created, :date_modified, :contentdm_number,
    :contentdm_file_name, :contentdm_file_path, :contentdm_collection_id, datastream: 'contentdmMetadata', multiple: false
-  
-  has_attributes :alternate_title, :adapted_from, :date_range, :lithographer_printer, :contributor, :cover_description, 
+
+  has_attributes :alternate_title, :adapted_from, :date_range, :lithographer_printer, :contributor, :cover_description,
     :stereotypical_object_note, :donor_information, :display_format, datastream: 'descMetadata', multiple: true
 
   has_attributes :folder, :location, :physical_description, datastream: 'physicalMetadata', multiple: true
-  
+
   has_attributes :file_name, :document_content, datastream: 'digitalMetadata', multiple: true
 
   has_attributes :created, :creator, datastream: 'creationMetadata', multiple: true

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -1,35 +1,34 @@
 class Video < TulCdm::Models::Audiovisual
-  
+
   has_metadata "descMetadata", type: VideoMetadata
   has_metadata "geographicMetadata", :type => TulCdm::Datastreams::GeographicDatastream
   has_metadata "physicalMetadata", :type => TulCdm::Datastreams::PhysicalDatastream
   has_metadata "digitalMetadata", :type => TulCdm::Datastreams::DigitalDatastream
   has_metadata "creationMetadata", :type => TulCdm::Datastreams::CreationDatastream
   has_metadata "volumeMetadata", :type => TulCdm::Datastreams::VolumeDatastream
-  
-  has_attributes :title,:format,:type, :publisher,:digital_collection,:digital_publisher,
-    :digital_specifications,:contact,:repository,:repository_collection, :language, 
-    :identifier, datastream: 'objectMetadata', multiple: true
 
-  has_attributes :avsource, :clip_summary, :date_broadcast, :ensemble_identifier, 
+  has_attributes :title,:format,:type, :publisher,:digital_collection,:digital_publisher,
+    :digital_specifications,:contact,:repository,:repository_collection, :language,
+    :identifier, :downloadable, datastream: 'objectMetadata', multiple: true
+
+  has_attributes :avsource, :clip_summary, :date_broadcast, :ensemble_identifier,
     :timecode_begin, :timecode_end, :transcript_filename, :original_source_summary,
     :original_source_title, datastream: 'avMetadata', multiple: true
-  
-  has_attributes :item_url, :oclc_number, :date_created, :date_modified, :contentdm_number, 
+
+  has_attributes :item_url, :oclc_number, :date_created, :date_modified, :contentdm_number,
     :contentdm_file_name, :contentdm_file_path, :contentdm_collection_id, datastream: 'contentdmMetadata', multiple: false
-  
+
   has_attributes :clip_title, :contributor, datastream: 'descMetadata', multiple: true
 
   has_attributes :geographic_subject, :organization_building, datastream: 'geographicMetadata', multiple: true
-  
+
   has_attributes :folder, :location, :physical_description, datastream: 'physicalMetadata', multiple: true
 
   has_attributes :notes, :personal_names, datastream: 'notationsMetadata', multiple: true
-  
+
   has_attributes :file_name, :document_content, datastream: 'digitalMetadata', multiple: true
 
   has_attributes :created, :creator, datastream: 'creationMetadata', multiple: true
 
 
 end
-

--- a/lib/cdm_utils.rb
+++ b/lib/cdm_utils.rb
@@ -94,6 +94,11 @@ module CDMUtils
       xml_text.gsub("</record><record>", "</record>\n  <record>")
     end
 
+    def self.insert_download_tag(document)
+      # Prohibit download by default
+      document.gsub("</record>", "  <Downloadable>No</Downloadable>\n  </record>")
+    end
+
     def self.download(config, coll=nil)
       # coll is the collection to import
       # If coll is nil, then import all the available collections
@@ -136,7 +141,22 @@ module CDMUtils
   module_function :convert_file # :nodoc:
 
   class Convert
+
+    def self.insert_downloadable_tag(document)
+      # Inserts default downloadable tag if it doesn't exist
+      xml_doc = Nokogiri::XML(document)
+      xml_doc.xpath("//record").each do |xml_element|
+        if xml_element.xpath("Downloadable").empty?
+          # Prohibit download by default
+          xml_element.add_child("<Downloadable>No</Downloadable>")
+        end
+      end
+      xml_doc.to_xml
+    end
+
     def self.conform(doc, collection_file_name, target_dir)
+
+      doc = insert_downloadable_tag(doc)
       
       #Strip out any bad keying from CDM
       replace = doc.gsub("&amp<", "<")
@@ -178,7 +198,7 @@ module CDMUtils
       replace32 = replace31.gsub("<Audio_Filename/>", "<File_Name/>")
       replace33 = replace32.gsub("<Video_Filename/>", "<File_Name/>")
       replace34 = replace33.gsub("<metadata>", "<metadata>\n  <manifest>\n    <contentdm_collection_id>#{collection_file_name}</contentdm_collection_id>\n    <Rails_Root>#{Rails.root}</Rails_Root>\n    <foxml_dir>#{target_dir}</foxml_dir>\n  </manifest>")
-      
+
     end
 
     def self.convert_file(file_name, foxml_dir)

--- a/lib/tasks/cdm_to_foxml_audio.xsl
+++ b/lib/tasks/cdm_to_foxml_audio.xsl
@@ -38,7 +38,7 @@
           <foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE=""/>
           <foxml:property NAME="info:fedora/fedora-system:def/model#createdDate" VALUE="{$current_time}"/>
           <foxml:property NAME="info:fedora/fedora-system:def/view#lastModifiedDate" VALUE=""/>
-        </foxml:objectProperties>                                        
+        </foxml:objectProperties>
         <foxml:datastream ID="RELS-EXT" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
           <foxml:datastreamVersion ID="RELS-EXT.0" LABEL="Fedora Object-to-Object Relationship Metadata" MIMETYPE="application/rdf+xml" >
             <foxml:xmlContent>
@@ -72,6 +72,7 @@
                 <xsl:apply-templates select="Repository_Collection"/>
                 <xsl:apply-templates select="Language"/>
                 <xsl:apply-templates select="Identifier"/>
+                <xsl:apply-templates select="Downloadable"/>
               </fields>
             </foxml:xmlContent>
           </foxml:datastreamVersion>
@@ -223,6 +224,9 @@
     <language><xsl:apply-templates /></language>
   </xsl:template>
   <xsl:template match="Identifier">
+    <identifier><xsl:apply-templates /></identifier>
+  </xsl:template>
+  <xsl:template match="Downloadable">
     <identifier><xsl:apply-templates /></identifier>
   </xsl:template>
   <xsl:template match="Item_URL">

--- a/lib/tasks/cdm_to_foxml_audio.xsl
+++ b/lib/tasks/cdm_to_foxml_audio.xsl
@@ -227,7 +227,7 @@
     <identifier><xsl:apply-templates /></identifier>
   </xsl:template>
   <xsl:template match="Downloadable">
-    <identifier><xsl:apply-templates /></identifier>
+    <downloadable><xsl:apply-templates /></downloadable>
   </xsl:template>
   <xsl:template match="Item_URL">
     <item_url><xsl:apply-templates /></item_url>

--- a/lib/tasks/cdm_to_foxml_clipping.xsl
+++ b/lib/tasks/cdm_to_foxml_clipping.xsl
@@ -38,7 +38,7 @@
           <foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE=""/>
           <foxml:property NAME="info:fedora/fedora-system:def/model#createdDate" VALUE="{$current_time}"/>
           <foxml:property NAME="info:fedora/fedora-system:def/view#lastModifiedDate" VALUE=""/>
-        </foxml:objectProperties>                                        
+        </foxml:objectProperties>
         <foxml:datastream ID="RELS-EXT" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
           <foxml:datastreamVersion ID="RELS-EXT.0" LABEL="Fedora Object-to-Object Relationship Metadata" MIMETYPE="application/rdf+xml" >
             <foxml:xmlContent>
@@ -72,6 +72,7 @@
                 <xsl:apply-templates select="Repository_Collection"/>
                 <xsl:apply-templates select="Language"/>
                 <xsl:apply-templates select="Identifier"/>
+                <xsl:apply-templates select="Downloadable"/>
               </fields>
             </foxml:xmlContent>
           </foxml:datastreamVersion>
@@ -210,6 +211,9 @@
     <language><xsl:apply-templates /></language>
   </xsl:template>
   <xsl:template match="Identifier">
+    <identifier><xsl:apply-templates /></identifier>
+  </xsl:template>
+  <xsl:template match="Downloadable">
     <identifier><xsl:apply-templates /></identifier>
   </xsl:template>
   <xsl:template match="Item_URL">

--- a/lib/tasks/cdm_to_foxml_clipping.xsl
+++ b/lib/tasks/cdm_to_foxml_clipping.xsl
@@ -214,7 +214,7 @@
     <identifier><xsl:apply-templates /></identifier>
   </xsl:template>
   <xsl:template match="Downloadable">
-    <identifier><xsl:apply-templates /></identifier>
+    <downloadable><xsl:apply-templates /></downloadable>
   </xsl:template>
   <xsl:template match="Item_URL">
     <item_url><xsl:apply-templates /></item_url>

--- a/lib/tasks/cdm_to_foxml_ephemera.xsl
+++ b/lib/tasks/cdm_to_foxml_ephemera.xsl
@@ -218,7 +218,7 @@
     <identifier><xsl:apply-templates /></identifier>
   </xsl:template>
   <xsl:template match="Downloadable">
-    <identifier><xsl:apply-templates /></identifier>
+    <downloadable><xsl:apply-templates /></downloadable>
   </xsl:template>
   <xsl:template match="Item_URL">
     <item_url><xsl:apply-templates /></item_url>

--- a/lib/tasks/cdm_to_foxml_ephemera.xsl
+++ b/lib/tasks/cdm_to_foxml_ephemera.xsl
@@ -38,7 +38,7 @@
           <foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE=""/>
           <foxml:property NAME="info:fedora/fedora-system:def/model#createdDate" VALUE="{$current_time}"/>
           <foxml:property NAME="info:fedora/fedora-system:def/view#lastModifiedDate" VALUE=""/>
-        </foxml:objectProperties>                                        
+        </foxml:objectProperties>
         <foxml:datastream ID="RELS-EXT" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
           <foxml:datastreamVersion ID="RELS-EXT.0" LABEL="Fedora Object-to-Object Relationship Metadata" MIMETYPE="application/rdf+xml" >
             <foxml:xmlContent>
@@ -72,6 +72,7 @@
                 <xsl:apply-templates select="Repository_Collection"/>
                 <xsl:apply-templates select="Language"/>
                 <xsl:apply-templates select="Identifier"/>
+                <xsl:apply-templates select="Downloadable"/>
               </fields>
             </foxml:xmlContent>
           </foxml:datastreamVersion>
@@ -214,6 +215,9 @@
     <language><xsl:apply-templates /></language>
   </xsl:template>
   <xsl:template match="Identifier">
+    <identifier><xsl:apply-templates /></identifier>
+  </xsl:template>
+  <xsl:template match="Downloadable">
     <identifier><xsl:apply-templates /></identifier>
   </xsl:template>
   <xsl:template match="Item_URL">

--- a/lib/tasks/cdm_to_foxml_manuscript.xsl
+++ b/lib/tasks/cdm_to_foxml_manuscript.xsl
@@ -38,7 +38,7 @@
           <foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE=""/>
           <foxml:property NAME="info:fedora/fedora-system:def/model#createdDate" VALUE="{$current_time}"/>
           <foxml:property NAME="info:fedora/fedora-system:def/view#lastModifiedDate" VALUE=""/>
-        </foxml:objectProperties>                                        
+        </foxml:objectProperties>
         <foxml:datastream ID="RELS-EXT" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
           <foxml:datastreamVersion ID="RELS-EXT.0" LABEL="Fedora Object-to-Object Relationship Metadata" MIMETYPE="application/rdf+xml" >
             <foxml:xmlContent>
@@ -72,6 +72,7 @@
                 <xsl:apply-templates select="Repository_Collection"/>
                 <xsl:apply-templates select="Language"/>
                 <xsl:apply-templates select="Identifier"/>
+                <xsl:apply-templates select="Downloadable"/>
               </fields>
             </foxml:xmlContent>
           </foxml:datastreamVersion>
@@ -218,6 +219,9 @@
     <language><xsl:apply-templates /></language>
   </xsl:template>
   <xsl:template match="Identifier">
+    <identifier><xsl:apply-templates /></identifier>
+  </xsl:template>
+  <xsl:template match="Downloadable">
     <identifier><xsl:apply-templates /></identifier>
   </xsl:template>
   <xsl:template match="Item_URL">

--- a/lib/tasks/cdm_to_foxml_manuscript.xsl
+++ b/lib/tasks/cdm_to_foxml_manuscript.xsl
@@ -222,7 +222,7 @@
     <identifier><xsl:apply-templates /></identifier>
   </xsl:template>
   <xsl:template match="Downloadable">
-    <identifier><xsl:apply-templates /></identifier>
+    <downloadable><xsl:apply-templates /></downloadable>
   </xsl:template>
   <xsl:template match="Item_URL">
     <item_url><xsl:apply-templates /></item_url>

--- a/lib/tasks/cdm_to_foxml_pamphlet.xsl
+++ b/lib/tasks/cdm_to_foxml_pamphlet.xsl
@@ -218,7 +218,7 @@
     <identifier><xsl:apply-templates /></identifier>
   </xsl:template>
   <xsl:template match="Downloadable">
-    <identifier><xsl:apply-templates /></identifier>
+    <downloadable><xsl:apply-templates /></downloadable>
   </xsl:template>
   <xsl:template match="Item_URL">
     <item_url><xsl:apply-templates /></item_url>

--- a/lib/tasks/cdm_to_foxml_pamphlet.xsl
+++ b/lib/tasks/cdm_to_foxml_pamphlet.xsl
@@ -38,7 +38,7 @@
           <foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE=""/>
           <foxml:property NAME="info:fedora/fedora-system:def/model#createdDate" VALUE="{$current_time}"/>
           <foxml:property NAME="info:fedora/fedora-system:def/view#lastModifiedDate" VALUE=""/>
-        </foxml:objectProperties>                                        
+        </foxml:objectProperties>
         <foxml:datastream ID="RELS-EXT" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
           <foxml:datastreamVersion ID="RELS-EXT.0" LABEL="Fedora Object-to-Object Relationship Metadata" MIMETYPE="application/rdf+xml" >
             <foxml:xmlContent>
@@ -72,6 +72,7 @@
                 <xsl:apply-templates select="Repository_Collection"/>
                 <xsl:apply-templates select="Language"/>
                 <xsl:apply-templates select="Identifier"/>
+                <xsl:apply-templates select="Downloadable"/>
               </fields>
             </foxml:xmlContent>
           </foxml:datastreamVersion>
@@ -214,6 +215,9 @@
     <language><xsl:apply-templates /></language>
   </xsl:template>
   <xsl:template match="Identifier">
+    <identifier><xsl:apply-templates /></identifier>
+  </xsl:template>
+  <xsl:template match="Downloadable">
     <identifier><xsl:apply-templates /></identifier>
   </xsl:template>
   <xsl:template match="Item_URL">

--- a/lib/tasks/cdm_to_foxml_periodical.xsl
+++ b/lib/tasks/cdm_to_foxml_periodical.xsl
@@ -38,7 +38,7 @@
           <foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE=""/>
           <foxml:property NAME="info:fedora/fedora-system:def/model#createdDate" VALUE="{$current_time}"/>
           <foxml:property NAME="info:fedora/fedora-system:def/view#lastModifiedDate" VALUE=""/>
-        </foxml:objectProperties>                                        
+        </foxml:objectProperties>
         <foxml:datastream ID="RELS-EXT" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
           <foxml:datastreamVersion ID="RELS-EXT.0" LABEL="Fedora Object-to-Object Relationship Metadata" MIMETYPE="application/rdf+xml" >
             <foxml:xmlContent>
@@ -72,6 +72,7 @@
                 <xsl:apply-templates select="Repository_Collection"/>
                 <xsl:apply-templates select="Language"/>
                 <xsl:apply-templates select="Identifier"/>
+                <xsl:apply-templates select="Downloadable"/>
               </fields>
             </foxml:xmlContent>
           </foxml:datastreamVersion>
@@ -189,6 +190,9 @@
     <language><xsl:apply-templates /></language>
   </xsl:template>
   <xsl:template match="Identifier">
+    <identifier><xsl:apply-templates /></identifier>
+  </xsl:template>
+  <xsl:template match="Downloadable">
     <identifier><xsl:apply-templates /></identifier>
   </xsl:template>
   <xsl:template match="Item_URL">

--- a/lib/tasks/cdm_to_foxml_periodical.xsl
+++ b/lib/tasks/cdm_to_foxml_periodical.xsl
@@ -193,7 +193,7 @@
     <identifier><xsl:apply-templates /></identifier>
   </xsl:template>
   <xsl:template match="Downloadable">
-    <identifier><xsl:apply-templates /></identifier>
+    <downloadable><xsl:apply-templates /></downloadable>
   </xsl:template>
   <xsl:template match="Item_URL">
     <item_url><xsl:apply-templates /></item_url>

--- a/lib/tasks/cdm_to_foxml_photograph.xsl
+++ b/lib/tasks/cdm_to_foxml_photograph.xsl
@@ -218,7 +218,7 @@
     <identifier><xsl:apply-templates /></identifier>
   </xsl:template>
   <xsl:template match="Downloadable">
-    <identifier><xsl:apply-templates /></identifier>
+    <downloadable><xsl:apply-templates /></downloadable>
   </xsl:template>
   <xsl:template match="Item_URL">
     <item_url><xsl:apply-templates /></item_url>

--- a/lib/tasks/cdm_to_foxml_photograph.xsl
+++ b/lib/tasks/cdm_to_foxml_photograph.xsl
@@ -38,7 +38,7 @@
           <foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE=""/>
           <foxml:property NAME="info:fedora/fedora-system:def/model#createdDate" VALUE="{$current_time}"/>
           <foxml:property NAME="info:fedora/fedora-system:def/view#lastModifiedDate" VALUE=""/>
-        </foxml:objectProperties>                                        
+        </foxml:objectProperties>
         <foxml:datastream ID="RELS-EXT" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
           <foxml:datastreamVersion ID="RELS-EXT.0" LABEL="Fedora Object-to-Object Relationship Metadata" MIMETYPE="application/rdf+xml" >
             <foxml:xmlContent>
@@ -72,6 +72,7 @@
                 <xsl:apply-templates select="Repository_Collection"/>
                 <xsl:apply-templates select="Language"/>
                 <xsl:apply-templates select="Identifier"/>
+                <xsl:apply-templates select="Downloadable"/>
               </fields>
             </foxml:xmlContent>
           </foxml:datastreamVersion>
@@ -214,6 +215,9 @@
     <language><xsl:apply-templates /></language>
   </xsl:template>
   <xsl:template match="Identifier">
+    <identifier><xsl:apply-templates /></identifier>
+  </xsl:template>
+  <xsl:template match="Downloadable">
     <identifier><xsl:apply-templates /></identifier>
   </xsl:template>
   <xsl:template match="Item_URL">

--- a/lib/tasks/cdm_to_foxml_poster.xsl
+++ b/lib/tasks/cdm_to_foxml_poster.xsl
@@ -38,7 +38,7 @@
           <foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE=""/>
           <foxml:property NAME="info:fedora/fedora-system:def/model#createdDate" VALUE="{$current_time}"/>
           <foxml:property NAME="info:fedora/fedora-system:def/view#lastModifiedDate" VALUE=""/>
-        </foxml:objectProperties>                                        
+        </foxml:objectProperties>
         <foxml:datastream ID="RELS-EXT" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
           <foxml:datastreamVersion ID="RELS-EXT.0" LABEL="Fedora Object-to-Object Relationship Metadata" MIMETYPE="application/rdf+xml" >
             <foxml:xmlContent>
@@ -72,6 +72,7 @@
                 <xsl:apply-templates select="Repository_Collection"/>
                 <xsl:apply-templates select="Language"/>
                 <xsl:apply-templates select="Identifier"/>
+                <xsl:apply-templates select="Downloadable"/>
               </fields>
             </foxml:xmlContent>
           </foxml:datastreamVersion>
@@ -230,6 +231,9 @@
     <language><xsl:apply-templates /></language>
   </xsl:template>
   <xsl:template match="Identifier">
+    <identifier><xsl:apply-templates /></identifier>
+  </xsl:template>
+  <xsl:template match="Downloadable">
     <identifier><xsl:apply-templates /></identifier>
   </xsl:template>
   <xsl:template match="Item_URL">

--- a/lib/tasks/cdm_to_foxml_poster.xsl
+++ b/lib/tasks/cdm_to_foxml_poster.xsl
@@ -234,7 +234,7 @@
     <identifier><xsl:apply-templates /></identifier>
   </xsl:template>
   <xsl:template match="Downloadable">
-    <identifier><xsl:apply-templates /></identifier>
+    <downloadable><xsl:apply-templates /></downloadable>
   </xsl:template>
   <xsl:template match="Item_URL">
     <item_url><xsl:apply-templates /></item_url>

--- a/lib/tasks/cdm_to_foxml_scholarship.xsl
+++ b/lib/tasks/cdm_to_foxml_scholarship.xsl
@@ -278,7 +278,7 @@
     <identifier><xsl:apply-templates /></identifier>
   </xsl:template>
   <xsl:template match="Downloadable">
-    <identifier><xsl:apply-templates /></identifier>
+    <downloadable><xsl:apply-templates /></downloadable>
   </xsl:template>
   <xsl:template match="Item_URL">
     <item_url><xsl:apply-templates /></item_url>

--- a/lib/tasks/cdm_to_foxml_scholarship.xsl
+++ b/lib/tasks/cdm_to_foxml_scholarship.xsl
@@ -38,7 +38,7 @@
           <foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE=""/>
           <foxml:property NAME="info:fedora/fedora-system:def/model#createdDate" VALUE="{$current_time}"/>
           <foxml:property NAME="info:fedora/fedora-system:def/view#lastModifiedDate" VALUE=""/>
-        </foxml:objectProperties>                                        
+        </foxml:objectProperties>
         <foxml:datastream ID="RELS-EXT" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
           <foxml:datastreamVersion ID="RELS-EXT.0" LABEL="Fedora Object-to-Object Relationship Metadata" MIMETYPE="application/rdf+xml" >
             <foxml:xmlContent>
@@ -72,6 +72,7 @@
                 <xsl:apply-templates select="Repository_Collection"/>
                 <xsl:apply-templates select="Language"/>
                 <xsl:apply-templates select="Identifier"/>
+                <xsl:apply-templates select="Downloadable"/>
               </fields>
             </foxml:xmlContent>
           </foxml:datastreamVersion>
@@ -230,7 +231,7 @@
   <xsl:template match="OCR_Note">
     <ocr_note><xsl:apply-templates /></ocr_note>
   </xsl:template>
-  
+
   <xsl:template match="Title">
     <title><xsl:apply-templates /></title>
   </xsl:template>
@@ -274,6 +275,9 @@
     <language><xsl:apply-templates /></language>
   </xsl:template>
   <xsl:template match="Identifier">
+    <identifier><xsl:apply-templates /></identifier>
+  </xsl:template>
+  <xsl:template match="Downloadable">
     <identifier><xsl:apply-templates /></identifier>
   </xsl:template>
   <xsl:template match="Item_URL">

--- a/lib/tasks/cdm_to_foxml_sheetmusic.xsl
+++ b/lib/tasks/cdm_to_foxml_sheetmusic.xsl
@@ -246,7 +246,7 @@
     <identifier><xsl:apply-templates /></identifier>
   </xsl:template>
   <xsl:template match="Downloadable">
-    <identifier><xsl:apply-templates /></identifier>
+    <downloadable><xsl:apply-templates /></downloadable>
   </xsl:template>
   <xsl:template match="Item_URL">
     <item_url><xsl:apply-templates /></item_url>

--- a/lib/tasks/cdm_to_foxml_sheetmusic.xsl
+++ b/lib/tasks/cdm_to_foxml_sheetmusic.xsl
@@ -38,7 +38,7 @@
           <foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE=""/>
           <foxml:property NAME="info:fedora/fedora-system:def/model#createdDate" VALUE="{$current_time}"/>
           <foxml:property NAME="info:fedora/fedora-system:def/view#lastModifiedDate" VALUE=""/>
-        </foxml:objectProperties>                                        
+        </foxml:objectProperties>
         <foxml:datastream ID="RELS-EXT" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
           <foxml:datastreamVersion ID="RELS-EXT.0" LABEL="Fedora Object-to-Object Relationship Metadata" MIMETYPE="application/rdf+xml" >
             <foxml:xmlContent>
@@ -72,6 +72,7 @@
                 <xsl:apply-templates select="Repository_Collection"/>
                 <xsl:apply-templates select="Language"/>
                 <xsl:apply-templates select="Identifier"/>
+                <xsl:apply-templates select="Downloadable"/>
               </fields>
             </foxml:xmlContent>
           </foxml:datastreamVersion>
@@ -242,6 +243,9 @@
     <language><xsl:apply-templates /></language>
   </xsl:template>
   <xsl:template match="Identifier">
+    <identifier><xsl:apply-templates /></identifier>
+  </xsl:template>
+  <xsl:template match="Downloadable">
     <identifier><xsl:apply-templates /></identifier>
   </xsl:template>
   <xsl:template match="Item_URL">

--- a/lib/tasks/cdm_to_foxml_video.xsl
+++ b/lib/tasks/cdm_to_foxml_video.xsl
@@ -231,7 +231,7 @@
     <identifier><xsl:apply-templates /></identifier>
   </xsl:template>
   <xsl:template match="Downloadable">
-    <identifier><xsl:apply-templates /></identifier>
+    <downloadable><xsl:apply-templates /></downloadable>
   </xsl:template>
   <xsl:template match="Item_URL">
     <item_url><xsl:apply-templates /></item_url>

--- a/lib/tasks/cdm_to_foxml_video.xsl
+++ b/lib/tasks/cdm_to_foxml_video.xsl
@@ -38,7 +38,7 @@
           <foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE=""/>
           <foxml:property NAME="info:fedora/fedora-system:def/model#createdDate" VALUE="{$current_time}"/>
           <foxml:property NAME="info:fedora/fedora-system:def/view#lastModifiedDate" VALUE=""/>
-        </foxml:objectProperties>                                        
+        </foxml:objectProperties>
         <foxml:datastream ID="RELS-EXT" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
           <foxml:datastreamVersion ID="RELS-EXT.0" LABEL="Fedora Object-to-Object Relationship Metadata" MIMETYPE="application/rdf+xml" >
             <foxml:xmlContent>
@@ -72,6 +72,7 @@
                 <xsl:apply-templates select="Repository_Collection"/>
                 <xsl:apply-templates select="Language"/>
                 <xsl:apply-templates select="Identifier"/>
+                <xsl:apply-templates select="Downloadable"/>
               </fields>
             </foxml:xmlContent>
           </foxml:datastreamVersion>
@@ -227,6 +228,9 @@
     <language><xsl:apply-templates /></language>
   </xsl:template>
   <xsl:template match="Identifier">
+    <identifier><xsl:apply-templates /></identifier>
+  </xsl:template>
+  <xsl:template match="Downloadable">
     <identifier><xsl:apply-templates /></identifier>
   </xsl:template>
   <xsl:template match="Item_URL">

--- a/lib/tul_cdm/datastreams/object_datastream.rb
+++ b/lib/tul_cdm/datastreams/object_datastream.rb
@@ -1,26 +1,25 @@
 module TulCdm::Datastreams
-  
+
   class ObjectDatastream < ActiveFedora::OmDatastream
 
     set_terminology do |t|
       t.root(path: "fields")
-      t.title(:index_as=>[:sortable, :stored_searchable], :type=>:string) 
-      t.date(:index_as=>[:facetable, :sortable, :stored_searchable], :type=>:string) 
-      t.subject(:index_as=>[:facetable, :stored_searchable], :type=>:string) 
+      t.title(:index_as=>[:sortable, :stored_searchable], :type=>:string)
+      t.date(:index_as=>[:facetable, :sortable, :stored_searchable], :type=>:string)
+      t.subject(:index_as=>[:facetable, :stored_searchable], :type=>:string)
       t.description index_as: :stored_searchable
-      t.format(:index_as=>[:facetable, :sortable, :stored_searchable], :type=>:string) 
-      t.type(:index_as=>[:facetable, :sortable, :stored_searchable], :type=>:string) 
-      t.publisher(:index_as=>[:facetable, :sortable, :stored_searchable], :type=>:string) 
-      t.digital_collection(:index_as=>[:facetable, :sortable, :stored_searchable], :type=>:string) 
-      t.digital_publisher(:index_as=>[:sortable, :stored_searchable], :type=>:string) 
+      t.format(:index_as=>[:facetable, :sortable, :stored_searchable], :type=>:string)
+      t.type(:index_as=>[:facetable, :sortable, :stored_searchable], :type=>:string)
+      t.publisher(:index_as=>[:facetable, :sortable, :stored_searchable], :type=>:string)
+      t.digital_collection(:index_as=>[:facetable, :sortable, :stored_searchable], :type=>:string)
+      t.digital_publisher(:index_as=>[:sortable, :stored_searchable], :type=>:string)
       t.digital_specifications
       t.contact index_as: :displayable
-      t.repository(:index_as=>[:facetable, :stored_searchable], :type=>:string) 
+      t.repository(:index_as=>[:facetable, :stored_searchable], :type=>:string)
       t.repository_collection index_as: :stored_searchable
       t.language index_as: :facetable
-      t.identifier(:index_as=>[:displayable, :sortable, :stored_searchable], :type=>:string) 
-      
-    
+      t.identifier(:index_as=>[:displayable, :sortable, :stored_searchable], :type=>:string)
+      t.downloadable
     end
 
     def self.xml_template
@@ -30,7 +29,7 @@ module TulCdm::Datastreams
     def prefix
       ""
     end
-  
+
   end
 
 end

--- a/lib/tul_cdm/datastreams/object_datastream.rb
+++ b/lib/tul_cdm/datastreams/object_datastream.rb
@@ -19,7 +19,7 @@ module TulCdm::Datastreams
       t.repository_collection index_as: :stored_searchable
       t.language index_as: :facetable
       t.identifier(:index_as=>[:displayable, :sortable, :stored_searchable], :type=>:string)
-      t.downloadable
+      t.downloadable(index_as: :displayable)
     end
 
     def self.xml_template

--- a/lib/tul_cdm/datastreams/object_datastream.rb
+++ b/lib/tul_cdm/datastreams/object_datastream.rb
@@ -19,7 +19,7 @@ module TulCdm::Datastreams
       t.repository_collection index_as: :stored_searchable
       t.language index_as: :facetable
       t.identifier(:index_as=>[:displayable, :sortable, :stored_searchable], :type=>:string)
-      # [TODO] Make this indexible, not-multivalued, and accessible, idealy displayable_si insteads of displayable_ssim
+      # [TODO] Make this indexible, not-multivalued, and accessible in document returned by Solr, idealy displayable_si insteads of displayable_ssm
       t.downloadable(index_as: :displayable)
     end
 

--- a/lib/tul_cdm/datastreams/object_datastream.rb
+++ b/lib/tul_cdm/datastreams/object_datastream.rb
@@ -19,6 +19,7 @@ module TulCdm::Datastreams
       t.repository_collection index_as: :stored_searchable
       t.language index_as: :facetable
       t.identifier(:index_as=>[:displayable, :sortable, :stored_searchable], :type=>:string)
+      # [TODO] Make this indexible, not-multivalued, and accessible, idealy displayable_si insteads of displayable_ssim
       t.downloadable(index_as: :displayable)
     end
 

--- a/spec/factories/digital_collections.rb
+++ b/spec/factories/digital_collections.rb
@@ -34,6 +34,16 @@ EOT
     allowed_ip_addresses "127.0.0.1, 10.1.1.1, 192.168.1.2"
   end
 
+  factory :private_digital_collection, class: DigitalCollection do
+    collection_alias "p16002coll14"
+    name "Franklin H. Littell Papers"
+    image_url "http://digital.library.temple.edu/ui/custom/default/collection/coll_p16002coll14/images/Littell_Landing_Pagev3.jpg"
+    thumbnail_url "http://digital.library.temple.edu/ui/custom/default/collection/default/resources/custompages/home/littell_dtl.jpg"
+    description ""
+    is_private true
+    allowed_ip_addresses "127.0.0.1, 10.1.1.1, 192.168.1.2"
+  end
+
   factory :private_digital_collection_allowed, class: DigitalCollection do
     collection_alias "p16002coll14"
     name "Franklin H. Littell Papers"

--- a/spec/lib/cdm_utils_spec.rb
+++ b/spec/lib/cdm_utils_spec.rb
@@ -106,12 +106,11 @@ describe 'List CONTENTdm collections' do
     end
 
     it "should convert a single collection file" do
-      pending ("FIXME: VCR throwing HTTPS error -- version of gem issue?")
       VCR.use_cassette "cdm-util-convert/should_convert_a_ContentDM_file" do
         downloaded = CDMUtils.download_one_collection(config, collection_name)
+        xml_file_count = `grep -ic "<record>" #{download_directory}/*`.to_i
         CDMUtils.convert_file(File.join(download_directory, collection_name + '.xml'), converted_directory)
         file_count = Dir[File.join(converted_directory, '*.xml')].count { |file| File.file?(file) }
-        xml_file_count = `grep -ic "<record>" #{download_directory}/*`.to_i
         expect(file_count).to eq(xml_file_count)
         xsd = Nokogiri::XML::Schema(open(schema_url))
         Dir.glob(File.join(converted_directory, '**', '*.xml')).each do |file|

--- a/spec/lib/cdm_utils_spec.rb
+++ b/spec/lib/cdm_utils_spec.rb
@@ -67,7 +67,7 @@ describe 'List CONTENTdm collections' do
         file_count = Dir[File.join(download_directory, '*.xml')].count { |file| File.file?(file) }
         file = File.join(download_directory, yearbook_collection_name + '.xml')
         doc = Nokogiri::XML(File.read(file))
-        # Tests for both metadata and attempted access to private collection
+        # Tests for OCR text tag
         expect(doc).to have_tag(ocr_text_tag)
         expect(doc.xpath(ocr_text_xpath).text).to match(match_text)
       end
@@ -101,6 +101,7 @@ describe 'List CONTENTdm collections' do
         expect(doc.search('contentdm_collection_id').text).to include collection_file
         expect(doc).to have_tag('Rails_Root')
         expect(doc).to have_tag('foxml_dir')
+        expect(doc).to have_tag('Downloadable')
       end
     end
 

--- a/spec/lib/tul_cdm/datastreams/object_datastream_spec.rb
+++ b/spec/lib/tul_cdm/datastreams/object_datastream_spec.rb
@@ -1,0 +1,50 @@
+describe "NotationsDatastream" do
+
+  subject do
+    datastream = TulCdm::Datastreams::ObjectDatastream.new
+    datastream.content = <<EODS
+<foxml:datastream ID="notationsMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+  <foxml:datastreamVersion ID="notationsMetadata.0" LABEL="notations metadata" MIMETYPE="text/xml">
+    <foxml:xmlContent>
+      <fields>
+        <title>Work Title</title>
+        <date>2015-04-21</date>
+        <subject>Miscelleneous</subject>
+        <description>Lorem ipsum dolor sit amet, at cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</title>
+        <format>Text</format>
+        <type>Manuscript</type>
+        <publisher>Random Object Press</publisher>
+        <digital_collection>Test Object Collection</digital_collection>
+        <digital_specifications></digital_specificaitons>
+        <contact>fred@example.com</contact>
+        <repository>Random Repository</repository>
+        <repository_collection>Any Object Collection</repository_collection>
+        <language>English</language>
+        <identifier>AB1234</identifier>
+        <downloadable>Yes</downloadable>
+      </fields>
+    </foxml:xmlContent>
+  </foxml:datastreamVersion>
+</foxml:datastream>
+EODS
+    datastream
+  end
+
+  it { is_expected.to have_term(:title) }
+  it { is_expected.to have_term(:date) }
+  it { is_expected.to have_term(:subject) }
+  it { is_expected.to have_term(:description) }
+  it { is_expected.to have_term(:format) }
+  it { is_expected.to have_term(:type) }
+  it { is_expected.to have_term(:publisher) }
+  it { is_expected.to have_term(:digital_collection) }
+  it { is_expected.to have_term(:digital_publisher) }
+  it { is_expected.to have_term(:digital_specifications) }
+  it { is_expected.to have_term(:contact) }
+  it { is_expected.to have_term(:repository) }
+  it { is_expected.to have_term(:repository_collection) }
+  it { is_expected.to have_term(:language) }
+  it { is_expected.to have_term(:identifier) }
+  it { is_expected.to have_term(:downloadable) }
+
+end

--- a/spec/models/audio_spec.rb
+++ b/spec/models/audio_spec.rb
@@ -7,8 +7,11 @@ RSpec.describe Audio, :type => :model do
     it { is_expected.to have_metadata_stream_of_type(AudioMetadata) }
     it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::GeographicDatastream) }
     it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::PhysicalDatastream) }
+    it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::DigitalDatastream) }
     it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::CreationDatastream) }
     it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::VolumeDatastream) }
 
+    it { is_expected.to respond_to(:title) }
+    it { is_expected.to respond_to(:downloadable) }
   end
 end

--- a/spec/models/clipping_spec.rb
+++ b/spec/models/clipping_spec.rb
@@ -11,5 +11,7 @@ RSpec.describe Clipping, :type => :model do
     it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::DigitalDatastream) }
     it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::CreationDatastream) }
 
+    it { is_expected.to respond_to(:title) }
+    it { is_expected.to respond_to(:downloadable) }
   end
 end

--- a/spec/models/ephemera_spec.rb
+++ b/spec/models/ephemera_spec.rb
@@ -10,5 +10,8 @@ RSpec.describe Ephemera, :type => :model do
     it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::NotationsDatastream) }
     it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::DigitalDatastream) }
     it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::CreationDatastream) }
+
+    it { is_expected.to respond_to(:title) }
+    it { is_expected.to respond_to(:downloadable) }
   end
 end

--- a/spec/models/manuscript_spec.rb
+++ b/spec/models/manuscript_spec.rb
@@ -11,5 +11,8 @@ RSpec.describe Manuscript, :type => :model do
     it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::DigitalDatastream) }
     it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::CreationDatastream) }
     it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::VolumeDatastream) }
+
+    it { is_expected.to respond_to(:title) }
+    it { is_expected.to respond_to(:downloadable) }
   end
 end

--- a/spec/models/periodical_spec.rb
+++ b/spec/models/periodical_spec.rb
@@ -8,5 +8,8 @@ RSpec.describe Periodical, :type => :model do
     it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::NotationsDatastream) }
     it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::DigitalDatastream) }
     it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::CreationDatastream) }
+
+    it { is_expected.to respond_to(:title) }
+    it { is_expected.to respond_to(:downloadable) }
   end
 end

--- a/spec/models/photograph_spec.rb
+++ b/spec/models/photograph_spec.rb
@@ -10,5 +10,8 @@ RSpec.describe Photograph, :type => :model do
     it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::NotationsDatastream) }
     it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::DigitalDatastream) }
     it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::CreationDatastream) }
+
+    it { is_expected.to respond_to(:title) }
+    it { is_expected.to respond_to(:downloadable) }
   end
 end

--- a/spec/models/poster_spec.rb
+++ b/spec/models/poster_spec.rb
@@ -9,5 +9,8 @@ RSpec.describe Poster, :type => :model do
     it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::DigitalDatastream) }
     it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::NotationsDatastream) }
     it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::CreationDatastream) }
+
+    it { is_expected.to respond_to(:title) }
+    it { is_expected.to respond_to(:downloadable) }
   end
 end

--- a/spec/models/scholarship_spec.rb
+++ b/spec/models/scholarship_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe Scholarship, :type => :model do
     it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::DigitalDatastream) }
     it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::CreationDatastream) }
     it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::VolumeDatastream) }
+
+    it { is_expected.to respond_to(:title) }
+    it { is_expected.to respond_to(:downloadable) }
   end
 end
-  

--- a/spec/models/sheet_music_spec.rb
+++ b/spec/models/sheet_music_spec.rb
@@ -9,5 +9,8 @@ RSpec.describe SheetMusic, :type => :model do
     it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::DigitalDatastream) }
     it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::CreationDatastream) }
     it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::VolumeDatastream) }
+
+    it { is_expected.to respond_to(:title) }
+    it { is_expected.to respond_to(:downloadable) }
   end
 end

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -1,15 +1,15 @@
 require 'rails_helper'
 
-RSpec.describe Pamphlet, :type => :model do
-  context 'Pamphlet Class' do
-    subject { Pamphlet.new }
+RSpec.describe Video, :type => :model do
+  context 'Video Class' do
+    subject { Video.new }
 
-    it { is_expected.to have_metadata_stream_of_type(PamphletMetadata) }
+    it { is_expected.to have_metadata_stream_of_type(VideoMetadata) }
     it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::GeographicDatastream) }
     it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::PhysicalDatastream) }
-    it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::NotationsDatastream) }
     it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::DigitalDatastream) }
     it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::CreationDatastream) }
+    it { is_expected.to have_metadata_stream_of_type(TulCdm::Datastreams::VolumeDatastream) }
 
     it { is_expected.to respond_to(:title) }
     it { is_expected.to respond_to(:downloadable) }


### PR DESCRIPTION
Implements optional download links using Object Datastream attribute. If the 'downloadable' tag does not exist, the tul_cdm:convert rake task adds Downloadable tag to the FOXML file with the option "No".
