### PR TITLE
Feature/tulcdm 52 links to collections composed of multiple collections

### DIFF
--- a/app/controllers/digital_collections_controller.rb
+++ b/app/controllers/digital_collections_controller.rb
@@ -51,7 +51,7 @@ class DigitalCollectionsController < ApplicationController
     end
 
     def digital_collection_params
-      params.require(:digital_collection).permit(:collection_alias, :name, :image_url, :thumbnail_url, :description, :priority, :is_private, :allowed_ip_addresses, :featured)
+      params.require(:digital_collection).permit(:collection_alias, :name, :image_url, :thumbnail_url, :description, :priority, :is_private, :allowed_ip_addresses, :featured, :custom_url, :is_custom_landing_page)
     end
 
     def verify_signed_in!

--- a/app/helpers/digital_collections_helper.rb
+++ b/app/helpers/digital_collections_helper.rb
@@ -20,4 +20,16 @@ module DigitalCollectionsHelper
     DigitalCollection.where(collection_alias: collection_id).first.description
   end
 
+  def landing_page(host, digital_collection)
+    if digital_collection.is_custom_landing_page? && !digital_collection.custom_url.blank?
+      return digital_collection.custom_url
+    end
+    return "#{host}/#{digital_collection.slug}"
+  end
+
+  def link_to_digital_collection(digital_collection)
+    digital_collection_path = digital_collection.custom_url.blank? ? path(digital_collection) : digital_collection.custom_url
+    link_to raw("Browse This Collection <span class=\"glyphicon glyphicon-circle-arrow-right\"></span>"), digital_collection_path
+  end
+
 end

--- a/app/helpers/digital_collections_helper.rb
+++ b/app/helpers/digital_collections_helper.rb
@@ -29,7 +29,7 @@ module DigitalCollectionsHelper
 
   def link_to_digital_collection(digital_collection)
     digital_collection_path = digital_collection.custom_url.blank? ? path(digital_collection) : digital_collection.custom_url
-    link_to raw("Browse This Collection <span class=\"glyphicon glyphicon-circle-arrow-right\"></span>"), digital_collection_path
+    link_to raw("#{t('tul_cdm.digital_collection.browse_collection')} <span class=\"glyphicon glyphicon-circle-arrow-right\"></span>"), digital_collection_path
   end
 
 end

--- a/app/views/digital_collections/_form.html.erb
+++ b/app/views/digital_collections/_form.html.erb
@@ -47,6 +47,14 @@
     <%= f.label :featured%><br>
    <%= f.select :featured, [['No', 'No'], ['Yes', 'Yes']] %>
   </div>
+  <div class="field">
+    <%= f.label :custom_url%><br>
+   <%= f.text_field :custom_url %>
+  </div>
+  <div class="field">
+    <%= f.label :is_custom_landing_page %><br>
+   <%= f.select :is_custom_landing_page, [['No', false], ['Yes', true]] %>
+  </div>
   <div class="actions">
     <%= f.submit %>
   </div>

--- a/app/views/digital_collections/_form.html.erb
+++ b/app/views/digital_collections/_form.html.erb
@@ -12,7 +12,7 @@
   <% end %>
 
   <div class="field">
-    <%= f.label :collection_alias %><br>
+    <%= f.label :collection_alias %> (<%= t('tul_cdm.digital_collection.collection_alias_helper_text') %>)<br>
     <%= f.text_field :collection_alias %>
   </div>
   <div class="field">

--- a/app/views/digital_collections/index.html.erb
+++ b/app/views/digital_collections/index.html.erb
@@ -13,13 +13,13 @@
                   browse <%= "#{digital_collection.name}" %>
                 </div>
               <% if (digital_collection.thumbnail_url) %>
-                <%= link_to (image_tag (digital_collection.thumbnail_url), :alt => "Browse #{digital_collection.name}"), digital_collection %>
+                <%= link_to (image_tag (digital_collection.thumbnail_url), :alt => "Browse #{digital_collection.name}"), landing_page(@host, digital_collection) %>
                   <% else  %>
                   <a href="<%= "#{@host}/#{digital_collection.collection_alias}" %>"><span class="collection-default-thumb glyphicon glyphicon-th"></span></a>
               <% end %>
           </div>
             <div class="collection-internals">
-              <span class="collection-name"><%= link_to digital_collection.name, digital_collection, :title => "Browse #{digital_collection.name}" %></span>
+              <span class="collection-name"><%= link_to digital_collection.name, landing_page(@host, digital_collection), :title => "Browse #{digital_collection.name}" %></span>
             </div>
           </div>
             <span class="admin">

--- a/app/views/digital_collections/index.html.erb
+++ b/app/views/digital_collections/index.html.erb
@@ -10,7 +10,7 @@
             <div class="collection-thumbnail">
               <div class="collection-item-attributes digcoll-overlay digcoll-cherry">
                 <div class="digcoll-text">
-                  browse <%= "#{digital_collection.name}" %>
+                  <%= "#{t('tul_cdm.digital_collection.browse_short')} #{digital_collection.name}" %>
                 </div>
               <% if (digital_collection.thumbnail_url) %>
                 <%= link_to (image_tag (digital_collection.thumbnail_url), :alt => "Browse #{digital_collection.name}"), landing_page(@host, digital_collection) %>

--- a/app/views/digital_collections/show.html.erb
+++ b/app/views/digital_collections/show.html.erb
@@ -5,7 +5,7 @@
     <%= @digital_collection.name %>
   </h1>
   <div class="collection-browse-link">
-    <%= link_to raw("Browse This Collection <span class=\"glyphicon glyphicon-circle-arrow-right\"></span>"), path(@digital_collection) %>
+    <%= link_to_digital_collection (@digital_collection)  %>
   </div>
 
 

--- a/config/locales/tul_cdm.en.yml
+++ b/config/locales/tul_cdm.en.yml
@@ -6,7 +6,7 @@ en:
     homepage:
       welcome: 'Welcome to the'
       intro_text: |+
-        Our Digital Collections site offers free worldwide access to the unique primary historical and cultural resources held by the Temple University Libraries and to selected scholarly works and other publications produced at Temple. We are actively digitizing additional materials; to suggest materials you believe should be digitized, please contact us at: <a href="mailto:diglib@temple.edu">diglib@temple.edu</a>. 
+        Our Digital Collections site offers free worldwide access to the unique primary historical and cultural resources held by the Temple University Libraries and to selected scholarly works and other publications produced at Temple. We are actively digitizing additional materials; to suggest materials you believe should be digitized, please contact us at: <a href="mailto:diglib@temple.edu">diglib@temple.edu</a>.
       featured_collections_heading: "Featured Collections"
       collections_by_subject_heading: "Browse Collections by Subject"
       subject_listing: |+
@@ -47,3 +47,6 @@ en:
     digital_collection:
       allowed_ip_helper_text: 'comma separated'
       not_available: 'Collection is unavailable'
+      browse_collection: 'Browse This Collection'
+      browse_short: 'Browse'
+      collection_alias_helper_text: "CONTENTdm alias or collection short name without spaces, e.g., 'stereotypicalimages'."

--- a/db/migrate/20150430154153_add_custom_url_to_digital_collection.rb
+++ b/db/migrate/20150430154153_add_custom_url_to_digital_collection.rb
@@ -1,0 +1,6 @@
+class AddCustomUrlToDigitalCollection < ActiveRecord::Migration
+  def change
+    add_column :digital_collections, :custom_url, :string
+    add_column :digital_collections, :is_custom_landing_page, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150421191625) do
+ActiveRecord::Schema.define(version: 20150430154153) do
 
   create_table "bookmarks", force: true do |t|
     t.integer  "user_id",       null: false
@@ -38,6 +38,8 @@ ActiveRecord::Schema.define(version: 20150421191625) do
     t.string   "allowed_ip_addresses"
     t.string   "featured"
     t.string   "slug"
+    t.string   "custom_url"
+    t.boolean  "is_custom_landing_page"
   end
 
   create_table "searches", force: true do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,10 +18,26 @@ collections = [
   priority:         11,
   is_private:       false,
   allowed_ip_addresses: "",
+  featured:         "Yes",
+  custom_url:       '',
+  is_custom_landing_page: false,
   description:      <<-END.gsub(/^ {6}/, '')
       <p><span>This collection of over 1,500 World War I posters in Temple University Libraries' Special Collections Research Center was donated by George F. Tyler in 1937. The posters provide a graphic portrayal of Allied propaganda used to educate the public and enlist support for the war effort. In addition, they serve as examples of the art, design, and printing techniques of the period.</span></p>
       <p><span>An <a href="http://gamma.library.temple.edu/exhibits/exhibits/show/george-tyler-wwi-poster-exhibi" target="new">exhibition</a> of a selection of the posters is accompanied by primary source material and commentary intended to provide additional context, insight, and interpretation.</span></p>
     END
+  },
+  {
+  collection_alias: 'cnrc',
+  name:             'Civil Rights in a Northern City: Philadelphia',
+  thumbnail_url:    'http://digital.library.temple.edu/ui/custom/default/collection/default/resources/custompages/home/girard_dtl.jpg',
+  image_url:        '',
+  priority:         21,
+  is_private:       false,
+  allowed_ip_addresses: "",
+  featured:         "No",
+  custom_url:       'http://northerncity.library.temple.edu/',
+  is_custom_landing_page: true,
+  description:      '',
   },
   {
   collection_alias: 'p16002coll14',
@@ -31,6 +47,9 @@ collections = [
   priority:         22,
   is_private:       false,
   allowed_ip_addresses: "",
+  featured:         "No",
+  custom_url:       '',
+  is_custom_landing_page: false,
   description:      <<-END.gsub(/^ {6}/, '')
       <p>A portion of the Franklin H. Littell papers has been digitized to offer online access.</p>
       <p>Franklin Littell (1917-2009), emeritus professor of religion at Temple University, led a distinguished career that spanned more than seventy years. He was a pacifist and activist, proponent of the Christian Laity and an advocate for new religious movements, an historian, political commentator and supporter of the State of Israel. He devoted ten years to work with the Protestant Churches and Laity in US occupied Germany and more than fifty years to the study and remembrance of the Holocaust and German Church Struggle. Though his activities and affiliations changed over time, he maintained strong beliefs in interfaith understanding and religious liberty his entire life.</p>
@@ -45,9 +64,33 @@ collections = [
   priority:         23,
   is_private:       false,
   allowed_ip_addresses: "",
+  featured:         "Yes",
+  custom_url:       '',
+  is_custom_landing_page: false,
   description:      <<-END.gsub(/^ {6}/, '')
       <p><span>Search here for sample clippings from the <strong>George D. McDowell Philadelphia Evening Bulletin Collection </strong>digitized in 2010 - 2013.</span></p>
     END
+  },
+  {
+  collection_alias: 'stereotypicalimgaes',
+  name:             'Stereotypical Images Teaching Collection',
+  thumbnail_url:    'http://digital.library.temple.edu/ui/custom/default/collection/default/resources/custompages/home/bertw_dtl.jpg',
+  image_url:        'http://digital.library.temple.edu/ui/custom/default/collection/default/resources/custompages/stereotypicalimages/cream_of_wheat.jpg',
+  priority:         71,
+  is_private:       false,
+  allowed_ip_addresses: "",
+  featured:         "No",
+  custom_url:       'http://0.0.0.0:3000/?utf8=✓&f%5Bdigital_collection_sim%5D%5B%5D=Stereotypical+Images+Teaching+Collection&search_field=digital_collection&q=p15037coll1+OR+p16002coll7',
+  is_custom_landing_page: false,
+  description:      <<-END.gsub(/^ {6}/, '')
+    <p>This is a teaching image collection designed to provide resources for faculty and students, studying historical representations of various cultural and ethnic groups.
+      The collection provides examples of stereotyping based on race, religion, gender, and other characteristics that have shaped and continue to shape American society,
+      and some images may be offensive to some viewers. This collection is in the process of being created and eventually a large number of groups will be represented.
+    </p>
+    <p>
+      To learn more about how the collection is used for pedagogy and scholarship, please see the <a href="/cdm/stereotypicalabout/">About Page</a>.
+    </p>
+  END
   },
   {
   collection_alias: 'p15037coll1',
@@ -57,6 +100,9 @@ collections = [
   priority:         73,
   is_private:       false,
   allowed_ip_addresses: "",
+  featured:         "Yes",
+  custom_url:       '',
+  is_custom_landing_page: false,
   description:      <<-END.gsub(/^ {6}/, '')
       <p><span>This sheet music published from the early 19th to early 20th centuries, from Temple University Libraries’ collections, contains lithographed and engraved cover art. These covers show remarkable designs and document developing printing techniques throughout more than 100 years. The collections include popular dances and songs, comic tunes that reveal the ironies and anxieties of the time, and music commemorating great exhibitions and honoring heroes and stars.</span></p>
     END
@@ -69,6 +115,9 @@ collections = [
   priority:         81,
   is_private:       false,
   allowed_ip_addresses: "",
+  featured:         "No",
+  custom_url:       '',
+  is_custom_landing_page: false,
   description:      <<-END.gsub(/^ {6}/, '')
       <p><span>The Library Prize for Undergraduate Research was established in 2004 to encourage the use of Library resources, to enhance the development of library research techniques, and to honor the best research projects produced each year by Temple University undergraduate students. Up to three projects are selected each year to win $1000. Winning entries exhibit: originality, depth, breadth, or sophistication in the use of library collections; exceptional ability to select, evaluate, synthesize, and utilize library resources in the creation of a project in any media; and evidence of personal growth through the acquisition of newfound knowledge.</span></p>
       <p><span>Also included in this collection are the winning entries for <strong>The Library Prize for Undergraduate Research on Sustainability &amp; the Environment</strong>. Established in the 2010-2011 academic year by Temple Libraries and Gale, a leading organization in e-research and educational publishing, this prize encourage undergraduate research and projects in the area of sustainability. Up to two projects are selected each year to win $1000.</span></p>
@@ -82,6 +131,9 @@ collections = [
   priority:         91,
   is_private:       false,
   allowed_ip_addresses: "",
+  featured:         "No",
+  custom_url:       '',
+  is_custom_landing_page: false,
   description:      <<-END.gsub(/^ {6}/, '')
       <p><span>Temple University has digitized&nbsp;a majority of its yearbooks, including the <em>Templar</em>, its general yearbook, as well as books from its allied health, dental, medical, nursing, podiatry&nbsp;and pharmacy schools. Some professional schools, such as Nursing, Podiatry, and Medicine, had their own pages in the <em>Templar</em> into the 1920s before starting their own yearbooks.</span></p>
       <p><span>Both the <em>Templar</em> and the medical school yearbook, <em>The Skull</em>, have enjoyed consistent publication and titling from their inception through to their present editions. Other professional school books have appeared less frequently and feature a wide array of titles. They are</span></p>
@@ -100,6 +152,9 @@ collections = [
   priority:         112,
   is_private:       false,
   allowed_ip_addresses: "",
+  featured:         "No",
+  custom_url:       '',
+  is_custom_landing_page: false,
   description:      <<-END.gsub(/^ {6}/, '')
       <p>The SCRC Audio digital collection contains audio files from holdings in the Special Collections Research Center (SCRC). Some of the objects in this collection are better contextualized in the following featured collection(s):</p>
       <ul>
@@ -115,6 +170,9 @@ collections = [
   priority:         131,
   is_private:       false,
   allowed_ip_addresses: "",
+  featured:         "No",
+  custom_url:       '',
+  is_custom_landing_page: false,
   description:      <<-END.gsub(/^ {6}/, '')
     <p>The SCRC Film and Video digital collection contains video files from holdings in the Special Collections Research Center (SCRC). Some of the objects in this collection are better contextualized in the following featured collection(s):</p>
     <ul>
@@ -130,6 +188,9 @@ collections = [
   priority:         131,
   is_private:       false,
   allowed_ip_addresses: "",
+  featured:         "No",
+  custom_url:       '',
+  is_custom_landing_page: false,
   description:      <<-END.gsub(/^ {6}/, '')
     <p>The SCRC Books and Pamphlets digital collection contains pamphlets and related materials from holdings in the Special Collections Research Center (SCRC). Some of the objects in this collection are better contextualized in the following featured collection(s):</p>
     <ul>
@@ -146,6 +207,25 @@ collections = [
     <ul>
       <li>
         <div class="cdm_style"><a href="/cdm/search/collection/p15037coll14/searchterm/Beth%20Heinly%20Zine%20Collection/field/digitb/mode/all/conn/and/order/title">Beth Heinly Zine Collection</a></div>
+      </li>
+    </ul>
+  END
+  },
+  {
+  collection_alias: 'p16002coll7',
+  name:             'Blockson Ephemera',
+  priority:         111,
+  is_private:       false,
+  allowed_ip_addresses: "",
+  featured:         "No",
+  custom_url:       '',
+  is_custom_landing_page: false,
+  description:      <<-END.gsub(/^ {6}/, '')
+    <p class="cdm_style" style="margin-top: 10px;">The Blockson Ephemera digital collection contains maps and lithographs from holdings in the Charles L. Blockson Afro-American Collection. Some of the objects in this collection are better contextualized in the following featured collection(s):
+    </p>
+    <ul>
+      <li>
+        <div class="cdm_style" style="margin-top: 10px;"><a href="http://stillfamily.library.temple.edu">William Still: An African-American Abolitionist</a></div>
       </li>
     </ul>
   END

--- a/spec/controllers/digital_collections_controller_spec.rb
+++ b/spec/controllers/digital_collections_controller_spec.rb
@@ -151,6 +151,8 @@ RSpec.describe DigitalCollectionsController, :type => :controller do
         expect(digital_collection.description).to eq new_attributes["description"]
         expect(digital_collection.is_private).to eq new_attributes["is_private"]
         expect(digital_collection.allowed_ip_addresses).to eq new_attributes["allowed_ip_addresses"]
+        expect(digital_collection.featured).to eq new_attributes["featured"]
+        expect(digital_collection.custom_url).to eq new_attributes["custom_url"]
       end
 
       it "assigns the requested digital_collection as @digital_collection" do

--- a/spec/factories/digital_collections.rb
+++ b/spec/factories/digital_collections.rb
@@ -64,4 +64,15 @@ EOT
     allowed_ip_addresses "1.1.1.1"
   end
 
+  factory :custom_collection, class: DigitalCollection do
+    collection_alias ""
+    name "Custom Collection"
+    image_url "http://digital.library.temple.edu/ui/custom/default/collection/coll_p16002coll14/images/Littell_Landing_Pagev3.jpg"
+    thumbnail_url "http://digital.library.temple.edu/ui/custom/default/collection/default/resources/custompages/home/littell_dtl.jpg"
+    description "A combination of muiltiple collections"
+    is_private false
+    allowed_ip_addresses ""
+    custom_url "/?utf8=✓&f%5Bdigital_collection_sim%5D%5B%5D=Stereotypical+Images+Teaching+Collection&search_field=digital_collection&q=p15037coll1+OR+p16002coll7"
+  end
+
 end


### PR DESCRIPTION
Provides for digital collections composed of custom URL such as Blacklight search queries and external links.
