### PR TITLE
Feature/tulcdm 61 refactor downloadable fields

### DIFF
--- a/spec/helpers/tul_cdm_helper_spec.rb
+++ b/spec/helpers/tul_cdm_helper_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the DigitalCollectionsHelper.
+
+RSpec.describe TulCdmHelper, :type => :helper do
+
+
+  describe "is_allowed" do
+
+    let (:solr_key) { 'downloadable' }
+    let (:document)  { Hash.new }
+
+    it "has a no" do
+      document[solr_key] = ['No', nil]
+      expect(allowed?(document, solr_key)).to_not be
+    end
+
+    it "has yes and no in any order" do
+      document[solr_key] = ['Yes','No']
+      expect(allowed?(document, solr_key)).to_not be
+      document[solr_key] = ['No', 'Yes']
+      expect(allowed?(document, solr_key)).to_not be
+    end
+
+    it "has a yes" do
+      document[solr_key] = ['Yes', nil]
+      expect(allowed?(document, solr_key)).to be
+      document[solr_key] = [nil, 'Yes']
+      expect(allowed?(document, solr_key)).to be
+    end
+
+    it "doesn't say" do
+      document[solr_key] = [nil, nil]
+      expect(allowed?(document, solr_key)).to_not be
+    end
+
+    it "has nothing" do
+      expect(allowed?(document, solr_key)).to_not be
+    end
+  end
+
+end


### PR DESCRIPTION
Originally branch was to make downloadable and downloadable_ocr into a univalue filed, but SOLR displayable is always multi-value. Branch refactors code instead to handle all multi-value downloadable\* instances that may occur.
