### PR TITLE
Restyle navigation bar

### DIFF
--- a/app/assets/stylesheets/tul_cdm.scss
+++ b/app/assets/stylesheets/tul_cdm.scss
@@ -72,7 +72,7 @@ html,body,#wrapper,#main-wrapper,#footer {
 
 #header-navbar .navbar-brand {
   width: 250px;
-  height: 60px;
+  height: 80px;
   margin-top: 10px;
   background: transparent url(/assets/logo.png) no-repeat top left;
 }
@@ -102,38 +102,42 @@ html,body,#wrapper,#main-wrapper,#footer {
 * Primary Navigation
 *
 ******/
+
 .prim-nav{
-  background-color: $temple-dark-grey;
-  height:30px;
-  border-bottom: $background-black solid 1px;
-  width: 100%;
+  height: 100px;
+  width: 280px;
+  float: right;
 }
 
 .prim-nav ul li{
   list-style: none;
   float: left;
-  border-right: $background-black 1px solid;
-  height: 30px;
-  width: 200px;
-  text-align: center;
-  padding-top: 5px;
+  width: 260px;
+  text-align: left;
+  padding-top: 8px;
+  padding-left: 0px;
 }
 
-.center-nav{
-  width: 1000px;
+.right-nav{
+  width: 280px;
   margin-left: auto;
   margin-right: auto;
 }
 
-.prim-nav ul li.first{
-  border-left: $background-black 1px solid;
-}
 
-
-.prim-nav a{
-  color: $text-white;
-  font-weight: bold;
-  font-size: 12px;
+.prim-nav a {
+  font: bold 14px Arial;
+  text-shadow: 0px -1px 0px rgba(0, 0, 0, 0.25);
+  background-color: $temple-cherry;
+  background-image: linear-gradient(to bottom, $temple-cherry, $temple-dark-cherry);
+  background-repeat: repeat-x;
+  color: white;
+  padding: 2px 6px 2px 6px;
+  border-color: $temple-dark-grey;
+  border-top: 1px solid #CCCCCC;
+  border-right: 1px solid #333333;
+  border-bottom: 1px solid #333333;
+  border-left: 1px solid #CCCCCC;
 }
 
 

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,27 +1,17 @@
 <div id="header-navbar" class="navbar navbar-inverse navbar-static-top" role="navigation">
   <div class="container">
     <div class="navbar-header">
-    <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#user-util-collapse">
-      <span class="sr-only">Toggle navigation</span>
-      <span class="icon-bar"></span>
-      <span class="icon-bar"></span>
-      <span class="icon-bar"></span>
-    </button>
     <%= link_to application_name, root_path, class: "navbar-brand" %>
     </div>
 
-    <div class="collapse navbar-collapse" id="user-util-collapse">
-      <%= render :partial=>'/user_util_links' %>
-    </div>
-  </div>
-  <div class="prim-nav">
-      <div class="center-nav">
-      <ul>
-        <li class="first"><a href="/">Digital Collections Home</a></li>
-        <li><a href="/?utf8=✓&search_field=all_fields&q=">Browse All Collections</a></li>
-        <li><a href="/about">About Temple Digital Collections</a></li>
-        <li><a href="/digital_collections">Explore Digital Collections</a></li>
-      </ul>
+    <div class="prim-nav">
+      <div class="right-nav">
+        <ul>
+          <li><a href="/">Digital Collections Home</a></li>
+          <li><a href="/about">About Temple Digital Collections</a></li>
+          <li><a href="/digital_collections">Our Digital Collections</a></li>
+        </ul>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
- Removed grey navigation bar.
- Removed "Browse all collections" link.
- Renamed "Explore digital collections" to "Our Digital Collections".
- Maked "Digital Collections Home", "About Temple Digital Collections"
  and "Our Digital Collections" seprate button links.
- Placed button links in the upper right area of the red banner.
- Increased link font size.
