### PR TITLE
Refactor downloadable and downloadable_ocr

### DIFF
--- a/app/models/audio.rb
+++ b/app/models/audio.rb
@@ -9,7 +9,9 @@ class Audio < TulCdm::Models::Audiovisual
 
   has_attributes :title,:format,:type, :publisher,:digital_collection,:digital_publisher,
     :digital_specifications,:contact,:repository,:repository_collection, :language,
-    :identifier, :downloadable, :downloadable_ocr, datastream: 'objectMetadata', multiple: true
+    :identifier, datastream: 'objectMetadata', multiple: true
+
+  has_attributes :downloadable, :downloadable_ocr, datastream: 'objectMetadata', multiple: false
 
   has_attributes :avsource, :clip_summary, :date_broadcast, :ensemble_identifier,
     :timecode_begin, :timecode_end, :transcript_filename, :original_source_summary,

--- a/app/models/clipping.rb
+++ b/app/models/clipping.rb
@@ -9,7 +9,9 @@ class Clipping < TulCdm::Models::Base
 
    has_attributes :title,:format,:type, :publisher,:digital_collection,:digital_publisher,
       :digital_specifications,:contact,:repository,:repository_collection, :language,
-      :identifier, :downloadable, :downloadable_ocr, datastream: 'objectMetadata', multiple: true
+      :identifier, datastream: 'objectMetadata', multiple: true
+
+  has_attributes :downloadable, :downloadable_ocr, datastream: 'objectMetadata', multiple: false
 
   has_attributes :item_url, :oclc_number, :date_created, :date_modified, :contentdm_number,
    :contentdm_file_name, :contentdm_file_path, :contentdm_collection_id, datastream: 'contentdmMetadata', multiple: false

--- a/app/models/ephemera.rb
+++ b/app/models/ephemera.rb
@@ -9,7 +9,9 @@ class Ephemera < TulCdm::Models::Base
 
   has_attributes :title,:format,:type, :publisher,:digital_collection,:digital_publisher,
       :digital_specifications,:contact,:repository,:repository_collection, :language,
-      :identifier, :downloadable, :downloadable_ocr, datastream: 'objectMetadata', multiple: true
+      :identifier, datastream: 'objectMetadata', multiple: true
+
+  has_attributes :downloadable, :downloadable_ocr, datastream: 'objectMetadata', multiple: false
 
   has_attributes :item_url, :oclc_number, :date_created, :date_modified, :contentdm_number,
    :contentdm_file_name, :contentdm_file_path, :contentdm_collection_id, datastream: 'contentdmMetadata', multiple: false

--- a/app/models/manuscript.rb
+++ b/app/models/manuscript.rb
@@ -10,7 +10,9 @@ class Manuscript < TulCdm::Models::Base
 
   has_attributes :title,:format,:type, :publisher,:digital_collection,:digital_publisher,
       :digital_specifications,:contact,:repository,:repository_collection, :language,
-      :identifier, :downloadable, :downloadable_ocr, datastream: :objectMetadata, multiple: true
+      :identifier, datastream: 'objectMetadata', multiple: true
+
+  has_attributes :downloadable, :downloadable_ocr, datastream: 'objectMetadata', multiple: false
 
   has_attributes :item_url, :oclc_number, :date_created, :date_modified, :contentdm_number,
    :contentdm_file_name, :contentdm_file_path, :contentdm_collection_id, datastream: 'contentdmMetadata', multiple: false

--- a/app/models/pamphlet.rb
+++ b/app/models/pamphlet.rb
@@ -9,7 +9,9 @@ class Pamphlet < TulCdm::Models::Base
 
   has_attributes :title,:format,:type, :publisher,:digital_collection,:digital_publisher,
       :digital_specifications,:contact,:repository,:repository_collection, :language,
-      :identifier, :downloadable, :downloadable_ocr, datastream: :objectMetadata, multiple: true
+      :identifier, datastream: 'objectMetadata', multiple: true
+
+  has_attributes :downloadable, :downloadable_ocr, datastream: 'objectMetadata', multiple: false
 
   has_attributes :item_url, :oclc_number, :date_created, :date_modified, :contentdm_number,
    :contentdm_file_name, :contentdm_file_path, :contentdm_collection_id, datastream: 'contentdmMetadata', multiple: false

--- a/app/models/periodical.rb
+++ b/app/models/periodical.rb
@@ -7,7 +7,9 @@ class Periodical < TulCdm::Models::Base
 
   has_attributes :title,:format,:type, :publisher,:digital_collection,:digital_publisher,
       :digital_specifications,:contact,:repository,:repository_collection, :language,
-      :identifier, :downloadable, :downloadable_ocr, datastream: :objectMetadata, multiple: true
+      :identifier, datastream: 'objectMetadata', multiple: true
+
+  has_attributes :downloadable, :downloadable_ocr, datastream: 'objectMetadata', multiple: false
 
   has_attributes :item_url, :oclc_number, :date_created, :date_modified, :contentdm_number,
    :contentdm_file_name, :contentdm_file_path, :contentdm_collection_id, datastream: 'contentdmMetadata', multiple: false

--- a/app/models/photograph.rb
+++ b/app/models/photograph.rb
@@ -9,7 +9,9 @@ class Photograph < TulCdm::Models::Base
 
   has_attributes :title,:format,:type, :publisher,:digital_collection,:digital_publisher,
       :digital_specifications,:contact,:repository,:repository_collection, :language,
-      :identifier, :downloadable, :downloadable_ocr, datastream: :objectMetadata, multiple: true
+      :identifier, datastream: 'objectMetadata', multiple: true
+
+  has_attributes :downloadable, :downloadable_ocr, datastream: 'objectMetadata', multiple: false
 
   has_attributes :item_url, :oclc_number, :date_created, :date_modified, :contentdm_number,
    :contentdm_file_name, :contentdm_file_path, :contentdm_collection_id, datastream: 'contentdmMetadata', multiple: false

--- a/app/models/poster.rb
+++ b/app/models/poster.rb
@@ -8,7 +8,9 @@ class Poster < TulCdm::Models::Base
 
   has_attributes :title,:format,:type, :publisher,:digital_collection,:digital_publisher,
       :digital_specifications,:contact,:repository,:repository_collection, :language,
-      :identifier, :downloadable, :downloadable_ocr, datastream: :objectMetadata, multiple: true
+      :identifier, datastream: 'objectMetadata', multiple: true
+
+  has_attributes :downloadable, :downloadable_ocr, datastream: 'objectMetadata', multiple: false
 
   has_attributes :item_url, :oclc_number, :date_created, :date_modified, :contentdm_number,
    :contentdm_file_name, :contentdm_file_path, :contentdm_collection_id, datastream: 'contentdmMetadata', multiple: false

--- a/app/models/scholarship.rb
+++ b/app/models/scholarship.rb
@@ -7,7 +7,9 @@ class Scholarship < TulCdm::Models::Base
 
   has_attributes :title,:format,:type, :publisher,:digital_collection,:digital_publisher,
       :digital_specifications,:contact,:repository,:repository_collection, :language,
-      :identifier, :downloadable, :downloadable_ocr, datastream: :objectMetadata, multiple: true
+      :identifier, datastream: 'objectMetadata', multiple: true
+
+  has_attributes :downloadable, :downloadable_ocr, datastream: 'objectMetadata', multiple: false
 
   has_attributes :item_url, :oclc_number, :date_created, :date_modified, :contentdm_number,
    :contentdm_file_name, :contentdm_file_path, :contentdm_collection_id, datastream: 'contentdmMetadata', multiple: false

--- a/app/models/sheetmusic.rb
+++ b/app/models/sheetmusic.rb
@@ -8,7 +8,9 @@ class Sheetmusic < TulCdm::Models::Base
 
   has_attributes :title,:format,:type, :publisher,:digital_collection,:digital_publisher,
       :digital_specifications,:contact,:repository,:repository_collection, :language,
-      :identifier, :downloadable, :downloadable_ocr, datastream: :objectMetadata, multiple: true
+      :identifier, datastream: 'objectMetadata', multiple: true
+
+  has_attributes :downloadable, :downloadable_ocr, datastream: 'objectMetadata', multiple: false
 
   has_attributes :item_url, :oclc_number, :date_created, :date_modified, :contentdm_number,
    :contentdm_file_name, :contentdm_file_path, :contentdm_collection_id, datastream: 'contentdmMetadata', multiple: false

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -9,7 +9,9 @@ class Video < TulCdm::Models::Audiovisual
 
   has_attributes :title,:format,:type, :publisher,:digital_collection,:digital_publisher,
     :digital_specifications,:contact,:repository,:repository_collection, :language,
-    :identifier, :downloadable, :downloadable_ocr, datastream: 'objectMetadata', multiple: true
+    :identifier, datastream: 'objectMetadata', multiple: true
+
+  has_attributes :downloadable, :downloadable_ocr, datastream: 'objectMetadata', multiple: false
 
   has_attributes :avsource, :clip_summary, :date_broadcast, :ensemble_identifier,
     :timecode_begin, :timecode_end, :transcript_filename, :original_source_summary,

--- a/app/views/catalog/_show_image.html.erb
+++ b/app/views/catalog/_show_image.html.erb
@@ -8,7 +8,7 @@
       <div id='document-content-viewer'>
         <%= document_content.join(" ") %>
       </div>
-      <%= content_tag :button, t('tul_cdm.viewer.download_ocr_text'), target: valid_filename(document["id"], "txt"), class: "downloadTrigger" %>
+      <%= link_to_download_ocr(document) %>
     <% end %>
   </div>
 </div>

--- a/lib/tul_cdm/datastreams/object_datastream.rb
+++ b/lib/tul_cdm/datastreams/object_datastream.rb
@@ -19,9 +19,8 @@ module TulCdm::Datastreams
       t.repository_collection index_as: :stored_searchable
       t.language index_as: :facetable
       t.identifier(:index_as=>[:displayable, :sortable, :stored_searchable], :type=>:string)
-      # [TODO] Make the downloadable fields indexible, not-multivalued, and accessible in document returned by Solr, idealy displayable_si insteads of displayable_ssm
-      t.downloadable(index_as: :displayable)
-      t.downloadable_ocr(index_as: :displayable)
+      t.downloadable index_as: [:facetable, :displayable]
+      t.downloadable_ocr index_as: [:facetable, :displayable]
     end
 
     def self.xml_template


### PR DESCRIPTION
Cannot make downloadable and downloadable_ocr attributes strictly non-multi-value and accessible by the views or helpers. This PR set the attributes to non-multi-value in the model, but have to use _ssm to access the attributes from the views and helpers.

Also fixes a bug that permitted downloadable_ocr for all images with OCR text even if downloadable_ocr was set to "No".
- Make downloadable attributes non-multivalued
- Make downloadable attributes facetable
- OCR'd text should use helper instead of calling Javascript directly
