### PR TITLE
Show 20 items per page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -47,7 +47,7 @@ class CatalogController < ApplicationController
               is_part_of_ssim
               about_statement_tesim',
       :qt => 'search',
-      :rows => 10
+      :rows => 20
     }
 
     # solr field configuration for search results/index views


### PR DESCRIPTION
Issue calls for renumbering from 1 on each page. It appears to already show that behavior.
Implemented default 20 items per page.
