### PR TITLE
Feature/tulcdm 133 differentiate metadata links

### DIFF
--- a/app/assets/stylesheets/tul_cdm.scss
+++ b/app/assets/stylesheets/tul_cdm.scss
@@ -322,7 +322,7 @@ h2.ocr-section-heading{
 #document .defList dd{
   padding-bottom: 20px;
   a:visited{
-    color: rgba(11, 46, 101, 0.66);
+    color: $temple-lavendar-grey;
   }
 }
 

--- a/app/assets/stylesheets/tul_cdm.scss
+++ b/app/assets/stylesheets/tul_cdm.scss
@@ -321,6 +321,9 @@ h2.ocr-section-heading{
 
 #document .defList dd{
   padding-bottom: 20px;
+  a:visited{
+    color: rgba(11, 46, 101, 0.66);
+  }
 }
 
 /******


### PR DESCRIPTION
Changes color of the visited anchor tag so it's different than regular text used in non-linked metadata tags.
