### PR TITLE
Feature/tulcdm 144 resize audioplayer for mobile device

### DIFF
--- a/app/helpers/tul_cdm_helper.rb
+++ b/app/helpers/tul_cdm_helper.rb
@@ -395,8 +395,8 @@ module TulCdmHelper
     ensemble_identifier = document[:ensemble_identifier_tesim].first
     width = "380"
     height = "36"
-    frame_width = 380
-    frame_height = 36 
+    frame_width = 400
+    frame_height = 56 
     audio_width = 380
     audio_height = 36
     ensemble_plugin = "https://ensemble.temple.edu/ensemble/app/plugin/plugin.aspx"

--- a/app/helpers/tul_cdm_helper.rb
+++ b/app/helpers/tul_cdm_helper.rb
@@ -393,6 +393,12 @@ module TulCdmHelper
     config = YAML.load_file(File.expand_path("#{Rails.root}/config/contentdm.yml", __FILE__))
     model = model_from_document(document)
     ensemble_identifier = document[:ensemble_identifier_tesim].first
+    width = "380"
+    height = "36"
+    frame_width = 380
+    frame_height = 36 
+    audio_width = 380
+    audio_height = 36
     ensemble_plugin = "https://ensemble.temple.edu/ensemble/app/plugin/plugin.aspx"
     ensemble_style_sheet = "https://ensemble.temple.edu/ensemble/app/plugin/css/ensembleEmbeddedContent.css"
 
@@ -406,6 +412,8 @@ module TulCdmHelper
       "autoPlay"       => false,
       "hideControls"   => false,
       "showCaptions"   => false,
+      "width"          => audio_width,
+      "height"         => audio_height,
       "audio"          => true,
       "q"              => config['cdm_archive'],
       "frameborder"    => 0
@@ -416,9 +424,12 @@ module TulCdmHelper
                           content_tag(:script,
                             "",
                             type: "text/javascript",
-                            src: player_src).html_safe,
+                            src: player_src,
+                            style: ["width: #{frame_width}px;", "height: #{frame_height}px;"],
+                            escape: true).html_safe,
                           class: "ensembleEmbeddedContent",
-                          id: "ensembleEmbeddedContent_#{ensemble_identifier}")
+                          id: "ensembleEmbeddedContent_#{ensemble_identifier}",
+                          style: ["width: #{width}px;", "height: #{height}px;"])
 
     output.html_safe
   end


### PR DESCRIPTION
Original player was the same size as a video player causing the controls to disappear behind the reader on mobile devices. This brings the size of the player in the space allotted.

The issue states that the volume control is inaccessible. There does not appear to be a volume control available in the embedded player on mobile devices.

![screen shot 2015-09-11 at 10 57 41 am](https://cloud.githubusercontent.com/assets/7852809/9818027/4ce7b6b6-5874-11e5-91fb-01669ad2c961.png)

The only way to access this control is to tap on the full screen icon, then the volume control is at the bottom of the full screen player.

![fullscreen player](https://cloud.githubusercontent.com/assets/7852809/9818040/5b8171bc-5874-11e5-8c22-e5e3c1085a41.png)

The [player wiki page](http://wiki.ensemblevideo.com/index.php?title=Plugin_Documentation_for_v3.2) says nothing in regards to the volume control.
