### PR TITLE
Remove "start over" from faceted search results.

### DIFF
--- a/app/assets/stylesheets/tul_cdm.scss
+++ b/app/assets/stylesheets/tul_cdm.scss
@@ -349,6 +349,10 @@ h2.ocr-section-heading{
   padding-left: 24px;
 }
 
+a#startOverLink{
+  display: none;
+}
+
 /******
 *
 * Advance Search Form
@@ -362,4 +366,3 @@ h2.ocr-section-heading{
     display: none;
   }
 }
-


### PR DESCRIPTION
- Style away the start over button rather than customizing catalog _constraints partial
