### PR TITLE
Removed "Our Digital Collections" link

### DIFF
--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -9,7 +9,6 @@
         <ul>
           <li><a href="/">Digital Collections Home</a></li>
           <li><a href="/about">About Temple Digital Collections</a></li>
-          <li><a href="/digital_collections">Our Digital Collections</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
TULCDM-166 Remove redundant "Our Digital Collections Link" from right side of the Nav Bar.
