### PR TITLE
Modified example link to library homepage

### DIFF
--- a/config/tul_cdm.yml.example
+++ b/config/tul_cdm.yml.example
@@ -1,1 +1,1 @@
-tul_cdm_organization_url: "http://example.com"
+tul_cdm_organization_url: "http://library.temple.edu"


### PR DESCRIPTION
- Modified example `tul_cdm` configuration file (`tul_cdm.yml.example`) to use the Temple library website instead of example.com.
- Modified `tul_cdm.yml` on the development server.
