### PR TITLE
Feature/tulcdm 105 add digital collection dropdown to searchbar

### DIFF
--- a/app/assets/stylesheets/tul_cdm.scss
+++ b/app/assets/stylesheets/tul_cdm.scss
@@ -310,23 +310,29 @@ h2.ocr-section-heading{
 *
 ******/
 
-#search-navbar .search-query-form input.search_q,#search-navbar .input-group-btn button#search{
-  font-size: 20px;
-  height:50px;
-  font-weight: bold;
-}
-
-#search-navbar .container{
-  text-align: center;
-}
-
-#search-navbar .container .search-query-form{
-  margin-right: auto;
-  margin-left: auto;
-  width: auto;
-}
-
 #search-navbar {
+  .container .search-query-form {
+    margin-right: auto;
+    margin-left: auto;
+    width: auto;
+
+    #q {
+      @media (min-width: $screen-lg) {
+        width: 500px;
+      }
+    }
+  }
+
+  .search-query-form input.search_q,#search-navbar .input-group-btn button#search {
+    font-size: 20px;
+    height:50px;
+    font-weight: bold;
+  }
+
+  .container {
+    text-align: center;
+  }
+
   .secondary-input-group {
     display: inline-block;
     .btn {
@@ -337,15 +343,9 @@ h2.ocr-section-heading{
       font-weight: bold;
     }
   }
-}
 
-#search-navbar {
-  .container .search-query-form {
-    #q {
-      @media (min-width: $screen-lg) {
-        width: 500px;
-      }
-    }
+  select {
+    width: 150px;
   }
 }
 

--- a/app/assets/stylesheets/tul_cdm.scss
+++ b/app/assets/stylesheets/tul_cdm.scss
@@ -321,13 +321,14 @@ h2.ocr-section-heading{
         width: 500px;
       }
     }
+
+    input.search_q, .input-group-btn button#search {
+      font-size: 20px;
+      height:50px;
+      font-weight: bold;
+    }
   }
 
-  .search-query-form input.search_q,#search-navbar .input-group-btn button#search {
-    font-size: 20px;
-    height:50px;
-    font-weight: bold;
-  }
 
   .container {
     text-align: center;

--- a/app/helpers/tul_cdm_helper.rb
+++ b/app/helpers/tul_cdm_helper.rb
@@ -590,32 +590,7 @@ module TulCdmHelper
   end
 
   def collections_fields
-    [ ['All Collections', ''],
-      'Allied Posters of World War I',
-      'Blockson Pamphlets',
-      'Blockson Photographs',
-      'City Parks Association Photographs',
-      'Civil Rights in a Northern City',
-      'Columbia Avenue Riots',
-      'Desegregation of Girard College',
-      'Franklin H. Littell Papers',
-      'George D. McDowell Philadelphia Evening Bulletin Clippings',
-      'George D. McDowell Philadelphia Evening Bulletin Photographs',
-      'Impulse Dance Annuals',
-      'KIDSNET at Temple University Libraries',
-      'Philadelphia Transit Strike of 1944',
-      'SCRC Audio',
-      'SCRC Ephemera',
-      'SCRC Film and Video',
-      'Stereotypical Images Teaching Collection',
-      'Temple Digital Sheet Music Collection',
-      'Temple Sheet Music Collections',
-      'Temple Undergraduate Research Prize Winners',
-      'Temple University Press E-Books',
-      'Urban Archives Photographs',
-      'William Still Collection',
-      'YWCA Philadelphia Branches Records'
-    ]
+    DigitalCollection.pluck(:name).unshift(["All Collections", ""])
   end
 
   ##

--- a/app/helpers/tul_cdm_helper.rb
+++ b/app/helpers/tul_cdm_helper.rb
@@ -590,7 +590,7 @@ module TulCdmHelper
   end
 
   def collections_fields
-    [ 'All Collections',
+    [ ['All Collections', ''],
       'Allied Posters of World War I',
       'Blockson Pamphlets',
       'Blockson Photographs',

--- a/app/helpers/tul_cdm_helper.rb
+++ b/app/helpers/tul_cdm_helper.rb
@@ -589,6 +589,35 @@ module TulCdmHelper
       :sort => response.params[:"f.#{facet_field}.facet.sort"] || response.params["facet.sort"])
   end
 
+  def collections_fields
+    [ 'All Collections',
+      'Allied Posters of World War I',
+      'Blockson Pamphlets',
+      'Blockson Photographs',
+      'City Parks Association Photographs',
+      'Civil Rights in a Northern City',
+      'Columbia Avenue Riots',
+      'Desegregation of Girard College',
+      'Franklin H. Littell Papers',
+      'George D. McDowell Philadelphia Evening Bulletin Clippings',
+      'George D. McDowell Philadelphia Evening Bulletin Photographs',
+      'Impulse Dance Annuals',
+      'KIDSNET at Temple University Libraries',
+      'Philadelphia Transit Strike of 1944',
+      'SCRC Audio',
+      'SCRC Ephemera',
+      'SCRC Film and Video',
+      'Stereotypical Images Teaching Collection',
+      'Temple Digital Sheet Music Collection',
+      'Temple Sheet Music Collections',
+      'Temple Undergraduate Research Prize Winners',
+      'Temple University Press E-Books',
+      'Urban Archives Photographs',
+      'William Still Collection',
+      'YWCA Philadelphia Branches Records'
+    ]
+  end
+
   ##
   # Render a collection of facet fields.
   # @see #render_facet_limit

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -2,14 +2,10 @@
     <%= render_hash_as_hidden_fields(params_for_search().except(:q, :search_field, :qt, :page, :utf8)) %>
 
     <div class="input-group">
-    <% unless search_fields.empty? %>
-
       <span class="input-group-addon">
-        <label for="search_field" class="sr-only"><%= t('blacklight.search.form.search_field.label') %></label>
-        <%= select_tag(:search_field, options_for_select(search_fields, h(params[:search_field])), :title => t('blacklight.search.form.search_field.title'), :class=>"search_field") %>
+        <%= select_tag("f[digital_collection_sim][]", options_for_select(collections_fields, h(params[:digital_collection])), :title => t('blacklight.search.form.collection_field.title'), :class=>"search_field") %>
         <span class="sr-only"><%= t('blacklight.search.form.search_field.post_label') %></span>
       </span>
-      <% end %>
       <label for="q" class="sr-only"><%= t('blacklight.search.form.q') %></label>
        <%= text_field_tag :q, params[:q], :placeholder => search_placeholder_text, :class => "search_q q form-control", :id => "q", :autofocus => should_autofocus_on_search_box? %>
 

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -3,7 +3,7 @@
 
     <div class="input-group">
       <span class="input-group-addon">
-        <%= select_tag("f[digital_collection_sim][]", options_for_select(collections_fields, h(params[:digital_collection])), :title => t('blacklight.search.form.collection_field.title'), :class=>"search_field") %>
+        <%= select_tag("f[digital_collection_sim][]", options_for_select(collections_fields), :title => t('blacklight.search.form.collection_field.title'), :class=>"search_field") %>
         <span class="sr-only"><%= t('blacklight.search.form.search_field.post_label') %></span>
       </span>
       <label for="q" class="sr-only"><%= t('blacklight.search.form.q') %></label>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -20,6 +20,8 @@ en:
         more_html: 'more »'
       placeholder:
         digital_collection: 'Search This Collection...'
+      form:
+        collections_search_field: 'Select Collections'
 
     basic_search_link: "Basic Search"
     advanced_search_link: "More Search Options"


### PR DESCRIPTION
Please review and test. Note that previous searches are carried over into subsequent digital collection searches. Workaround, hit "start over" button between searches. This can be addressed in TULCDM-107.
