### PR TITLE
Feature/tulcdm 101 integrate contextual information

### DIFF
--- a/app/assets/stylesheets/BookReader/BookReader.css
+++ b/app/assets/stylesheets/BookReader/BookReader.css
@@ -573,7 +573,6 @@ a.BRgrey:visited   { color: #666; }
 div#BRpage {
     float: right;
     width: 280px;
-    padding-left:12px;
     text-align: right;
 }
 div#BRnav {

--- a/app/assets/stylesheets/scaffolds.css.scss
+++ b/app/assets/stylesheets/scaffolds.css.scss
@@ -46,8 +46,8 @@
 ******/
 
 .cpd-thumb{
-  width: 980px;
-  padding-bottom: 20px
+  width: 918px;
+  padding: 0px 15px 15px 0px;
 }
 
 .cpd-thumb .thumb-single{

--- a/app/assets/stylesheets/tul_cdm.scss
+++ b/app/assets/stylesheets/tul_cdm.scss
@@ -52,6 +52,16 @@
         max-width:100%;
       }
     }
+    .related-resources-list {
+      ul {
+        padding-left: 0px;
+        list-style-position: inside;
+        li {
+          padding-bottom: 0px;
+          color: black;
+        }
+      }
+    }
   }
 }
 

--- a/app/assets/stylesheets/tul_cdm.scss
+++ b/app/assets/stylesheets/tul_cdm.scss
@@ -34,9 +34,25 @@
 *
 ******/
 
-#sidebar-right{
- float: right;
- width: 200px;
+#sidebar {
+  .well {
+    float: right;
+
+    h2#atc-title {
+      font-size: 20px;
+    }
+    .atc-icon {
+      float: left;
+      width: 60px;
+      height: 60px;
+      padding: 1px;
+      margin: 6px 12px 0 0;
+      img {
+        max-width:100%;
+        max-width:100%;
+      }
+    }
+  }
 }
 
 /******

--- a/app/assets/stylesheets/tul_cdm.scss
+++ b/app/assets/stylesheets/tul_cdm.scss
@@ -186,7 +186,7 @@ html,body,#wrapper,#main-wrapper,#footer {
   border: 1px solid $background-black;
   overflow-y: scroll;
   height: 100px;
-  width: 980px;
+  width: 880px;
 }
 
 h2.ocr-section-heading{

--- a/app/assets/stylesheets/tul_cdm.scss
+++ b/app/assets/stylesheets/tul_cdm.scss
@@ -186,7 +186,6 @@ html,body,#wrapper,#main-wrapper,#footer {
   border: 1px solid $background-black;
   overflow-y: scroll;
   height: 100px;
-  width: 880px;
 }
 
 h2.ocr-section-heading{

--- a/app/controllers/digital_collections_controller.rb
+++ b/app/controllers/digital_collections_controller.rb
@@ -63,7 +63,8 @@ class DigitalCollectionsController < ApplicationController
 
     def digital_collection_params
       params.require(:digital_collection).permit(:collection_alias, :name, :image_url, :thumbnail_url, :description, :short_description, :priority,
-                                                 :is_private, :allowed_ip_addresses, :featured, :custom_url, :is_custom_landing_page, :proxy_url_prefix)
+                                                 :is_private, :allowed_ip_addresses, :featured, :custom_url, :is_custom_landing_page, :proxy_url_prefix,
+                                                 :finding_aid_link, :finding_aid_title, :catalog_record, :catalog_record_title)
     end
 
     def verify_signed_in!

--- a/app/helpers/tul_cdm_helper.rb
+++ b/app/helpers/tul_cdm_helper.rb
@@ -699,11 +699,20 @@ module TulCdmHelper
     digital_collection = DigitalCollection.where({ collection_alias: digital_collection_alias }).first
     collection_link = get_collection_link(document)
 
-    thumbnail_link = image_tag (digital_collection.thumbnail_url)
-    related_resources = 
-      link_to(content_tag(:h2, digital_collection.name), collection_link) +
-      thumbnail_link +
+    thumbnail_link = content_tag(:div, class: "atc-icon") do
+      link_to(collection_link) do
+        image_tag(digital_collection.thumbnail_url)
+      end
+    end
+
+    description = content_tag(:div, id: "atc-description") do
       content_tag(:p, digital_collection.short_description) 
+    end
+
+    related_resources = 
+      link_to(content_tag(:h2, digital_collection.name, id: "atc-title"), collection_link) +
+      thumbnail_link +
+      description
     return related_resources.html_safe
   end
 

--- a/app/helpers/tul_cdm_helper.rb
+++ b/app/helpers/tul_cdm_helper.rb
@@ -509,6 +509,33 @@ module TulCdmHelper
     return collection_set
   end
 
+  def render_related_resources(document)
+    rc_label = content_tag("span", nil, class: "related-resource-label") do t('tul_cdm.related_resources_label') end
+    digital_collection_alias = document['contentdm_collection_id_tesim'].first
+    digital_collection = DigitalCollection.where({ collection_alias: digital_collection_alias }).first
+    collection_link = get_collection_link(document)
+    related_resources = content_tag(:h1, rc_label) +
+      link_to(content_tag(:h2, digital_collection.name), collection_link) +
+      content_tag(:p, digital_collection.short_description) 
+    return related_resources.html_safe
+  end
+
+  # TODO: Refactor get_collection_link with set_collection_link
+  def get_collection_link(document)
+    if model_from_document(document) != "Collection"
+      digital_collection_alias = document['contentdm_collection_id_tesim'].first
+      digital_collection = DigitalCollection.where({ collection_alias: digital_collection_alias }).first
+      query = "/?f[digital_collection_sim][]=#{document['digital_collection_tesim'].first.gsub(' ', '%20') if document['digital_collection_tesim']}"
+      if digital_collection
+        url_for(digital_collection) + query
+      else
+        query
+      end
+    else
+      return nil
+    end
+  end
+
   def get_related_objects(collection_id)
     related_objects = ActiveFedora::Base.where(is_member_of_ssim: collection_id).to_a
     return related_objects

--- a/app/helpers/tul_cdm_helper.rb
+++ b/app/helpers/tul_cdm_helper.rb
@@ -489,18 +489,12 @@ module TulCdmHelper
     flash[:notice] = "Display: #{display_field.items.length}"
   end
 
-  def set_collection_link(document)
-    if model_from_document(document) != "Collection"
-      digital_collection_alias = document['contentdm_collection_id_tesim'].first
-      digital_collection = DigitalCollection.where({ collection_alias: digital_collection_alias }).first
-      query = "/?f[digital_collection_sim][]=#{document['digital_collection_tesim'].first.gsub(' ', '%20') if document['digital_collection_tesim']}"
-      if digital_collection
-        link_to t('tul_cdm.document.more_like_this_text'), url_for(digital_collection) + query
-      else
-        link_to t('tul_cdm.document.more_like_this_text'), query
-      end
+  def collection_link(document)
+    link = get_collection_link(document)
+    unless link.nil?
+      link_to t('tul_cdm.document.more_like_this_text'), link
     else
-      return nil
+      nil
     end
   end
 
@@ -520,7 +514,6 @@ module TulCdmHelper
     return related_resources.html_safe
   end
 
-  # TODO: Refactor get_collection_link with set_collection_link
   def get_collection_link(document)
     if model_from_document(document) != "Collection"
       digital_collection_alias = document['contentdm_collection_id_tesim'].first

--- a/app/helpers/tul_cdm_helper.rb
+++ b/app/helpers/tul_cdm_helper.rb
@@ -693,6 +693,20 @@ module TulCdmHelper
     end
   end
 
+  def render_about_this_collection(document)
+    rc_label = content_tag("span", nil, class: "related-resource-label") do t('tul_cdm.document.about_this_collection_title') end
+    digital_collection_alias = document['contentdm_collection_id_tesim'].first
+    digital_collection = DigitalCollection.where({ collection_alias: digital_collection_alias }).first
+    collection_link = get_collection_link(document)
+
+    thumbnail_link = image_tag (digital_collection.thumbnail_url)
+    related_resources = 
+      link_to(content_tag(:h2, digital_collection.name), collection_link) +
+      thumbnail_link +
+      content_tag(:p, digital_collection.short_description) 
+    return related_resources.html_safe
+  end
+
 end
 
 ##

--- a/app/helpers/tul_cdm_helper.rb
+++ b/app/helpers/tul_cdm_helper.rb
@@ -503,10 +503,15 @@ module TulCdmHelper
     return collection_set
   end
 
+  # Get collection for the document
+  def document_collection(document)
+    digital_collection_alias = document['contentdm_collection_id_tesim'].first
+    return DigitalCollection.where({ collection_alias: digital_collection_alias }).first
+  end
+
   def render_related_resources(document)
     rc_label = content_tag("span", nil, class: "related-resource-label") do t('tul_cdm.related_resources_label') end
-    digital_collection_alias = document['contentdm_collection_id_tesim'].first
-    digital_collection = DigitalCollection.where({ collection_alias: digital_collection_alias }).first
+    digital_collection = document_collection(document)
     collection_link = get_collection_link(document)
     related_resources = content_tag(:h1, rc_label) +
       link_to(content_tag(:h2, digital_collection.name), collection_link) +
@@ -516,8 +521,7 @@ module TulCdmHelper
 
   def get_collection_link(document)
     if model_from_document(document) != "Collection"
-      digital_collection_alias = document['contentdm_collection_id_tesim'].first
-      digital_collection = DigitalCollection.where({ collection_alias: digital_collection_alias }).first
+    digital_collection = document_collection(document)
       query = "/?f[digital_collection_sim][]=#{document['digital_collection_tesim'].first.gsub(' ', '%20') if document['digital_collection_tesim']}"
       if digital_collection
         url_for(digital_collection) + query
@@ -691,29 +695,6 @@ module TulCdmHelper
         render_facet_value(facet_field, item, suppress_link: true)
       end
     end
-  end
-
-  def render_about_this_collection(document)
-    rc_label = content_tag("span", nil, class: "related-resource-label") do t('tul_cdm.document.about_this_collection_title') end
-    digital_collection_alias = document['contentdm_collection_id_tesim'].first
-    digital_collection = DigitalCollection.where({ collection_alias: digital_collection_alias }).first
-    collection_link = get_collection_link(document)
-
-    thumbnail_link = content_tag(:div, class: "atc-icon") do
-      link_to(collection_link) do
-        image_tag(digital_collection.thumbnail_url)
-      end
-    end
-
-    description = content_tag(:div, id: "atc-description") do
-      content_tag(:p, digital_collection.short_description) 
-    end
-
-    related_resources = 
-      link_to(content_tag(:h2, digital_collection.name, id: "atc-title"), collection_link) +
-      thumbnail_link +
-      description
-    return related_resources.html_safe
   end
 
 end

--- a/app/helpers/tul_cdm_helper.rb
+++ b/app/helpers/tul_cdm_helper.rb
@@ -532,7 +532,7 @@ module TulCdmHelper
         query
       end
     else
-      return nil
+      nil
     end
   end
 

--- a/app/views/catalog/_about_this_collection.html.erb
+++ b/app/views/catalog/_about_this_collection.html.erb
@@ -11,4 +11,10 @@
   <div id="atc-description">
     <%= content_tag(:p, digital_collection.short_description) %>
   </div>
+  <div class="related-resources-list">
+    <ul>
+      <li>Finding Aid: <%= link_to(digital_collection.finding_aid_title, digital_collection.finding_aid_link) %></li>
+      <li>Catalog Record: <%= link_to(digital_collection.catalog_record_title, digital_collection.catalog_record_link) %></li>
+    </ul>
+  </div>
 </div>

--- a/app/views/catalog/_about_this_collection.html.erb
+++ b/app/views/catalog/_about_this_collection.html.erb
@@ -1,0 +1,14 @@
+<div class="widget", id="about-this-collection">
+  <% digital_collection = document_collection(@document) %>
+  <% collection_link = get_collection_link(@document) %>
+  <span class="related-resource-label">
+    <%= t('tul_cdm.document.about_this_collection_title') %>
+  </span>
+  <h2 id="atc-title"><%= link_to(digital_collection.name, collection_link) %></h2>
+  <div class="atc-icon">
+    <%= link_to(image_tag(digital_collection.thumbnail_url), collection_link) %>
+  </div>
+  <div id="atc-description">
+    <%= content_tag(:p, digital_collection.short_description) %>
+  </div>
+</div>

--- a/app/views/catalog/_about_this_collection.html.erb
+++ b/app/views/catalog/_about_this_collection.html.erb
@@ -13,8 +13,8 @@
   </div>
   <div class="related-resources-list">
     <ul>
-      <li>Finding Aid: <%= link_to(digital_collection.finding_aid_title, digital_collection.finding_aid_link) %></li>
-      <li>Catalog Record: <%= link_to(digital_collection.catalog_record_title, digital_collection.catalog_record_link) %></li>
+      <li><%= t('tul_cdm.document.finding_aid_label') %>: <%= link_to(digital_collection.finding_aid_title, digital_collection.finding_aid_link) %></li>
+      <li><%= t('tul_cdm.document.catalog_record_label') %>: <%= link_to(digital_collection.catalog_record_title, digital_collection.catalog_record_link) %></li>
     </ul>
   </div>
 </div>

--- a/app/views/catalog/_about_this_collection.html.erb
+++ b/app/views/catalog/_about_this_collection.html.erb
@@ -17,4 +17,7 @@
       <li><%= t('tul_cdm.document.catalog_record_label') %>: <%= link_to(digital_collection.catalog_record_title, digital_collection.catalog_record_link) %></li>
     </ul>
   </div>
+  <div>
+  <%= content_tag(:p, t('tul_cdm.digital_collection.research_help_html').html_safe )  %>
+  </div>
 </div>

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -1,8 +1,6 @@
   
 <%# unless @document.more_like_this.empty? %>
 <div class="well" id="sidebar-mlt">
-  <ul class="nav nav-list">
-    <%= render_about_this_collection(@document) %>
-  </ul>
+  <%= render partial: "about_this_collection" %>
 </div><!--/well -->
 <%# end %>

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -1,9 +1,8 @@
   
-<% unless @document.more_like_this.empty? %>
+<%# unless @document.more_like_this.empty? %>
 <div class="well" id="sidebar-mlt">
   <ul class="nav nav-list">
-  <li class="nav-header">More Like This</li>
-    <%= render :collection => @document.more_like_this, :partial => 'show_more_like_this', :as => :document %>
+    <%= render_about_this_collection(@document) %>
   </ul>
 </div><!--/well -->
-<% end %>
+<%# end %>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -27,7 +27,7 @@
 
   </div>
 </div>
-<dd><%= set_collection_link(@document) %></dd>
+<dd><%= collection_link(@document) %></dd>
 </div>
 
 <div id="sidebar" class="col-md-3 col-sm-4">

--- a/app/views/digital_collections/_form.html.erb
+++ b/app/views/digital_collections/_form.html.erb
@@ -63,6 +63,22 @@
    <%= f.label :proxy_url_prefix %><br>
    <%= f.text_field :proxy_url_prefix %>
   </div>
+  <div class="field">
+   <%= f.label :finding_aid_title %><br>
+   <%= f.text_field :finding_aid_title %>
+  </div>
+  <div class="field">
+   <%= f.label :finding_aid_link %><br>
+   <%= f.text_field :finding_aid_link %>
+  </div>
+  <div class="field">
+   <%= f.label :catalog_record_title %><br>
+   <%= f.text_field :catalog_record_title %>
+  </div>
+  <div class="field">
+   <%= f.label :catalog_record_link %><br>
+   <%= f.text_field :catalog_record_link %>
+  </div>
   <div class="actions">
     <%= f.submit %>
   </div>

--- a/config/locales/tul_cdm.en.yml
+++ b/config/locales/tul_cdm.en.yml
@@ -23,6 +23,7 @@ en:
     document:
       more_like_this_text: "Digital Collection Homepage"
       related_resources_label: 'Related Resources'
+      about_this_collection_title: 'About this Collection'
     digital_collection:
       allowed_ip_helper_text: 'comma separated'
       not_available: 'Collection is unavailable'

--- a/config/locales/tul_cdm.en.yml
+++ b/config/locales/tul_cdm.en.yml
@@ -21,6 +21,7 @@ en:
       possible_ocr_errors: 'OCR Text (may contain machine-generated errors)'
     document:
       more_like_this_text: "Digital Collection Homepage"
+      related_resources_label: 'Related Resources'
     digital_collection:
       allowed_ip_helper_text: 'comma separated'
       not_available: 'Collection is unavailable'

--- a/config/locales/tul_cdm.en.yml
+++ b/config/locales/tul_cdm.en.yml
@@ -38,6 +38,7 @@ en:
       restricted_collection_title: "Staff Only - Restricted Collections"
       format_based_collections_title: "Other Collections"
       format_based_collections_text: "In order to manage the materials we select and scan from within various collections, we group them by collecting area and format of material. Some of the material in the following collections appears in the subject/theme collections listed above and is best searched and used in that subject context. Other material appears only in these collections and may be discovered through keyword and other searches."
+      research_help_html: For Research Help, visit the <a href="https://library.temple.edu/scrc/research">SCRC Research Help page</a>.
     multifacets:
       title: 'Search across collections'
       form:

--- a/config/locales/tul_cdm.en.yml
+++ b/config/locales/tul_cdm.en.yml
@@ -24,6 +24,8 @@ en:
       more_like_this_text: "Digital Collection Homepage"
       related_resources_label: 'Related Resources'
       about_this_collection_title: 'About this Collection'
+      finding_aid_label: 'Finding Aid'
+      catalog_record_label: 'Catalog Record'
     digital_collection:
       allowed_ip_helper_text: 'comma separated'
       not_available: 'Collection is unavailable'

--- a/db/migrate/20151223213742_add_contextual_information_to_digital_collection.rb
+++ b/db/migrate/20151223213742_add_contextual_information_to_digital_collection.rb
@@ -1,0 +1,8 @@
+class AddContextualInformationToDigitalCollection < ActiveRecord::Migration
+  def change
+    add_column :digital_collections, :finding_aid_title, :string
+    add_column :digital_collections, :finding_aid_link, :string
+    add_column :digital_collections, :catalog_record_title, :string
+    add_column :digital_collections, :catalog_record_link, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151030143357) do
+ActiveRecord::Schema.define(version: 20151223213742) do
 
   create_table "bookmarks", force: true do |t|
     t.integer  "user_id",       null: false
@@ -43,6 +43,10 @@ ActiveRecord::Schema.define(version: 20151030143357) do
     t.boolean  "is_format_based"
     t.string   "short_description"
     t.string   "proxy_url_prefix"
+    t.string   "finding_aid_title"
+    t.string   "finding_aid_link"
+    t.string   "catalog_record_title"
+    t.string   "catalog_record_link"
   end
 
   create_table "searches", force: true do |t|

--- a/db/seeds.rb.example
+++ b/db/seeds.rb.example
@@ -24,6 +24,10 @@ collections = [
   is_custom_landing_page: false,
   is_format_based:  false,
   proxy_url_prefix: '',
+  finding_aid_link: 'http://example.com/finding_aid/featrcoll1',
+  finding_aid_title:'Featured Example Finding Aid',
+  catalog_record_link:'http://example.com/catalog_record/featrcoll1',
+  catalog_record_title:'Featured Example Catalog Record',
   short_description: '',
   description:      <<-END.gsub(/^ {6}/, '')
       <p><span>This is a sample featured collection</span></p>
@@ -42,6 +46,10 @@ collections = [
   is_custom_landing_page: false,
   is_format_based:  false,
   proxy_url_prefix: '',
+  finding_aid_link: 'http://example.com/finding_aid/reglrcoll1',
+  finding_aid_title:'Example Finding Aid',
+  catalog_record_link:'http://example.com/catalog_record/reglrcoll1',
+  catalog_record_title:'Example Catalog Record',
   short_description: '',
   description:      <<-END.gsub(/^ {6}/, '')
       <p><span>This is a sample regular collection</span></p>

--- a/spec/factories/digital_collections.rb
+++ b/spec/factories/digital_collections.rb
@@ -14,6 +14,8 @@ EOT
     short_description "Franklin Littell\'s Papers"
     is_private false
     allowed_ip_addresses ""
+    finding_aid "http://example.com/finding_aid"
+    catalog_record "http://example.com/catalog_record"
   end
 
   factory :updated_digital_object, class: DigitalCollection do

--- a/spec/helpers/tul_cdm_helper_spec.rb
+++ b/spec/helpers/tul_cdm_helper_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe TulCdmHelper, :type => :helper do
     end
   end
 
-  describe "set_collection_link" do
+  describe "collection_link" do
 
     let (:document) { Hash.new }
     let (:digital_collection) { FactoryGirl.create(:digital_collection) }
@@ -51,8 +51,8 @@ RSpec.describe TulCdmHelper, :type => :helper do
         document["active_fedora_model_ssi"] = ""
         document["digital_collection_tesim"] = [digital_collection.name]
 
-        expect(set_collection_link(document)).to match(/#{url_for(digital_collection)}/)
-        expect(set_collection_link(document)).to match(/#{document["digital_collection_tesim"].first.gsub(" ", "%20")}/)
+        expect(collection_link(document)).to match(/#{url_for(digital_collection)}/)
+        expect(collection_link(document)).to match(/#{document["digital_collection_tesim"].first.gsub(" ", "%20")}/)
       end
     end
 
@@ -63,8 +63,8 @@ RSpec.describe TulCdmHelper, :type => :helper do
         document["active_fedora_model_ssi"] = ""
         document["digital_collection_tesim"] = ["A Digital Collection"]
 
-        expect(set_collection_link(document)).to_not match(/#{url_for(digital_collection)}/)
-        expect(set_collection_link(document)).to match(/#{document["digital_collection_tesim"].first.gsub(" ", "%20")}/)
+        expect(collection_link(document)).to_not match(/#{url_for(digital_collection)}/)
+        expect(collection_link(document)).to match(/#{document["digital_collection_tesim"].first.gsub(" ", "%20")}/)
       end
     end
   end

--- a/spec/helpers/tul_cdm_helper_spec.rb
+++ b/spec/helpers/tul_cdm_helper_spec.rb
@@ -69,4 +69,19 @@ RSpec.describe TulCdmHelper, :type => :helper do
     end
   end
 
+  context 'render_related_resources' do
+    let (:document) { Hash.new }
+    let (:digital_collection) { FactoryGirl.create(:digital_collection) }
+
+    it "links to the digital collection" do
+      document["contentdm_collection_id_tesim"] = [digital_collection.collection_alias]
+      document["active_fedora_model_ssi"] = ""
+      document["digital_collection_tesim"] = [digital_collection.name]
+      rendered_related_resources = render_related_resources(document)
+
+      expect(rendered_related_resources).to match(/#{digital_collection.name}/)
+      expect(rendered_related_resources).to match(/#{document["digital_collection_tesim"].first.gsub(" ", "%20")}/)
+    end
+  end
+
 end

--- a/spec/helpers/tul_cdm_helper_spec.rb
+++ b/spec/helpers/tul_cdm_helper_spec.rb
@@ -69,6 +69,29 @@ RSpec.describe TulCdmHelper, :type => :helper do
     end
   end
 
+  context 'get_collection_link' do
+    let (:digital_collection) {
+      FactoryGirl.create(:digital_collection)
+    }
+
+    let (:document) {
+      {
+        "contentdm_collection_id_tesim" => [digital_collection.collection_alias],
+        "active_fedora_model_ssi" => "",
+        "digital_collection_tesim" => [digital_collection.name]
+      }
+    }
+
+    it "links to the digital collection" do
+      expect(get_collection_link(document)).to match(/#{url_for(digital_collection)}\/\?f\[digital_collection_sim\]\[\]=#{document["digital_collection_tesim"].first.gsub(" ", "%20")}/)
+    end
+
+    it "does not links to the digital collection" do
+      document["active_fedora_model_ssi"] = "Collection"
+      expect(get_collection_link(document)).to be_nil
+    end
+  end
+
   context 'render_related_resources' do
     let (:document) { Hash.new }
     let (:digital_collection) { FactoryGirl.create(:digital_collection) }

--- a/spec/models/digital_collection_spec.rb
+++ b/spec/models/digital_collection_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe DigitalCollection, :type => :model do
     it { is_expected.to have_attribute(:allowed_ip_addresses) }
     it { is_expected.to have_attribute(:is_format_based) }
     it { is_expected.to have_attribute(:proxy_url_prefix) }
+    it { is_expected.to have_attribute(:finding_aid_link) }
+    it { is_expected.to have_attribute(:finding_aid_title) }
+    it { is_expected.to have_attribute(:catalog_record_link) }
+    it { is_expected.to have_attribute(:catalog_record_title) }
   end
 
   describe "Object" do


### PR DESCRIPTION
Added Finding Aid and Catalog Record links to Related Resources widget.

Note that this PR does not ensure that links are kept within the context of both the repository and digital collections if there are more than one digital collection for the object.
