### PR TITLE
Force basic search from top search bar

### DIFF
--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag search_action_url, :method => :get, :id => 'basic-search', :class => 'search-query-form form-inline clearfix navbar-form' do %>
+<%= form_tag '/', :method => :get, :id => 'basic-search', :class => 'search-query-form form-inline clearfix navbar-form' do %>
     <%= render_hash_as_hidden_fields(params_for_search().except(:q, :search_field, :qt, :page, :utf8)) %>
 
     <div class="input-group">


### PR DESCRIPTION
Original code would return a search action URL of the form "/advanced?...". In this PR, it's forced to "/?...". This doesn't address why the submit doesn't return any results and simply returns to the advanced search from.
