### PR TITLE
Remove path from @host in digital collection controller

### DIFF
--- a/app/controllers/digital_collections_controller.rb
+++ b/app/controllers/digital_collections_controller.rb
@@ -8,13 +8,13 @@ class DigitalCollectionsController < ApplicationController
   add_breadcrumb "Explore Digital Collections", '/digital_collections'
 
   def index
-    @host = "http://#{request.env["HTTP_HOST"]}/digital_collections"
+    @host = "http://#{request.env["HTTP_HOST"]}"
     @digital_collections = viewable_collections
     respond_with(@digital_collections)
   end
 
   def restricted
-    @host = "http://#{request.env["HTTP_HOST"]}/digital_collections"
+    @host = "http://#{request.env["HTTP_HOST"]}"
     @digital_collections = private_collections
     respond_with(@digital_collections)
   end


### PR DESCRIPTION
@skng5 Fixes the issue that was causing the links to landing pages to fail on the Explore digital collections page.
