### PR TITLE
Ignore precompiled assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@
 # Ignore bundler config.
 /.bundle
 
+#ignore precompiled assets
+vendor/bundle/
+public/aassets/
+
 # Ignore the default SQLite database.
 /db/*.sqlite3
 /db/*.sqlite3-journal


### PR DESCRIPTION
Ignore files created when we run `rake assets:precompile`
