### PR TITLE
Makes home breadcrumb root

### DIFF
--- a/app/views/catalog/_search_header.html.erb
+++ b/app/views/catalog/_search_header.html.erb
@@ -1,5 +1,5 @@
-<% add_breadcrumb "Home", :root_path %>
-<% add_breadcrumb "Explore Digital Collections", '/digital_collections' %>
+<% add_breadcrumb "Home", '/ ' %>
+<% add_breadcrumb t('tul_cdm.digital_collection.collections_title'), '/digital_collections' %>
 <% add_breadcrumb "Browse", request.path %>
 <% #add_breadcrumb render_search_to_s_filters(params), request.path %>
 

--- a/app/views/catalog/_search_header.html.erb
+++ b/app/views/catalog/_search_header.html.erb
@@ -1,5 +1,5 @@
-<% add_breadcrumb "Home", '/ ' %>
-<% add_breadcrumb t('tul_cdm.digital_collection.collections_title'), '/digital_collections' %>
+<% add_breadcrumb "Home", "#{root_path} " %>
+<% add_breadcrumb t('tul_cdm.digital_collection.collections_title'), root_path + "digital_collections" %>
 <% add_breadcrumb "Browse", request.path %>
 <% #add_breadcrumb render_search_to_s_filters(params), request.path %>
 

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,5 +1,5 @@
-<% add_breadcrumb "Home", :root_path %>
-<% add_breadcrumb "Explore Digital Collections", '/digital_collections' %>
+<% add_breadcrumb "Home", root_path %>
+<% add_breadcrumb t('tul_cdm.digital_collection.collections_title'), '/digital_collections' %>
 <% if @document["digital_collection_tesim"] %>
   <% @document["digital_collection_tesim"].each do |dc| %>
     <% add_breadcrumb dc, File.join(['/digital_collections', get_collection_alias(dc)]) %>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,5 +1,5 @@
-<% add_breadcrumb "Home", root_path %>
-<% add_breadcrumb t('tul_cdm.digital_collection.collections_title'), '/digital_collections' %>
+<% add_breadcrumb "Home", "#{root_path} " %>
+<% add_breadcrumb t('tul_cdm.digital_collection.collections_title'), root_path + "digital_collections" %>
 <% if @document["digital_collection_tesim"] %>
   <% @document["digital_collection_tesim"].each do |dc| %>
     <% add_breadcrumb dc, File.join(['/digital_collections', get_collection_alias(dc)]) %>


### PR DESCRIPTION
- Search header will not create a root link the conventional way. Had to
  explicitly code the forward slash followed by a space to make it work.
  Investigate further.
- Use localized text for Explore Digital Collection text in views and
  methods. Not available in class startup code for
  digital_collections_controller.
