### PR TITLE
Replaces blacklight monkey patch

### DIFF
--- a/app/helpers/tul_cdm_helper.rb
+++ b/app/helpers/tul_cdm_helper.rb
@@ -730,40 +730,6 @@ module TulCdmHelper
 
 end
 
-##
-# Override Blacklight bug which will not render sidebar facets in alphabetical order
-#
-module Blacklight::RequestBuilders
-  ##
-  # Add any existing facet limits, stored in app-level HTTP query
-  # as :f, to solr as appropriate :fq query.
-  def add_facet_fq_to_solr(solr_parameters, user_params)
-    # Force blacklgiht to render facets in alphabetical order
-    solr_parameters["facet.sort"] = "index"
-
-    # convert a String value into an Array
-    if solr_parameters[:fq].is_a? String
-      solr_parameters[:fq] = [solr_parameters[:fq]]
-    end
-
-    # :fq, map from :f.
-    if ( user_params[:f])
-      f_request_params = user_params[:f]
-
-      # Hack to ensure that duplaicte Digital collections facets are not stacked
-      # when searching by collection.
-      # @TODO - Move this logic to param handler
-      f_request_params[:digital_collection_sim].uniq!
-      f_request_params.each_pair do |facet_field, value_list|
-        Array(value_list).each do |value| next if value.blank? # skip empty strings
-          solr_parameters.append_filter_query facet_value_to_fq_string(facet_field, value)
-        end
-      end
-    end
-  end
-end
-
-
 module Blacklight
   class DocumentPresenter
 


### PR DESCRIPTION
- Overrides default behavior (bug?) that always sorts facets by count
  even if index is specified in add_facet_field.
- Replaces blacklight facet patch: #42 
